### PR TITLE
patch to allow using iterators with stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "sl-sh"
-version = "0.9.67"
+version = "0.9.68"
 dependencies = [
  "cfg-if",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sl-sh"
-version = "0.9.67"
+version = "0.9.68"
 authors = ["Steven Stanfield <stanfield@scarecrowtech.com>"]
 edition = "2018"
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -110,7 +110,7 @@ fn declare_var(
                             s
                         )))
                     } else {
-                        let idx = syms.insert(*s);
+                        let idx = syms.insert(s);
                         location.replace(SymLoc::Stack(idx));
                         Ok(())
                     }
@@ -145,7 +145,7 @@ fn patch_symbol(
             if let Some(idx) = syms.get(name) {
                 location.replace(SymLoc::Stack(idx));
             } else if syms.can_capture(name) {
-                let idx = syms.insert_capture(name, environment);
+                let idx = syms.insert_capture(name);
                 location.replace(SymLoc::Stack(idx));
             } else if let Some(binding) = syms.namespace().borrow().get_with_outer(name) {
                 location.replace(SymLoc::Ref(binding));

--- a/src/builtins_file.rs
+++ b/src/builtins_file.rs
@@ -107,7 +107,7 @@ fn builtin_cd(
     if let Ok(oldpwd) = env::current_dir() {
         env::set_var("OLDPWD", oldpwd);
     }
-    if let Err(e) = env::set_current_dir(&root) {
+    if let Err(e) = env::set_current_dir(root) {
         eprintln!("Error changing to {}, {}", root.display(), e);
         Ok(Expression::make_nil())
     } else {

--- a/src/builtins_io.rs
+++ b/src/builtins_io.rs
@@ -228,12 +228,7 @@ fn builtin_read_line(
                         // XXX TODO- something better if/when support binary.
                         let mut line = String::new();
                         if 0 == f.read_line(&mut line)? {
-                            let input = Expression::alloc_data(ExpEnum::String("".into(), None));
-                            let error = Expression::alloc_data(ExpEnum::Symbol(
-                                ":unexpected-eof",
-                                SymLoc::None,
-                            ));
-                            Ok(Expression::alloc_data(ExpEnum::Values(vec![input, error])))
+                            Ok(Expression::make_nil())
                         } else {
                             Ok(Expression::alloc_data(ExpEnum::String(line.into(), None)))
                         }
@@ -241,12 +236,7 @@ fn builtin_read_line(
                     FileState::Stdin => {
                         let mut line = String::new();
                         if 0 == io::stdin().read_line(&mut line)? {
-                            let input = Expression::alloc_data(ExpEnum::String("".into(), None));
-                            let error = Expression::alloc_data(ExpEnum::Symbol(
-                                ":unexpected-eof",
-                                SymLoc::None,
-                            ));
-                            Ok(Expression::alloc_data(ExpEnum::Values(vec![input, error])))
+                            Ok(Expression::make_nil())
                         } else {
                             Ok(Expression::alloc_data(ExpEnum::String(line.into(), None)))
                         }

--- a/src/builtins_str.rs
+++ b/src/builtins_str.rs
@@ -852,7 +852,7 @@ fn builtin_codepoints(
     match &next_arg_d.data {
         ExpEnum::String(s, _) => with_str(s),
         ExpEnum::Char(s) => with_str(s),
-        ExpEnum::CodePoint(c) => with_str(&*format!("{}", c)),
+        ExpEnum::CodePoint(c) => with_str(&format!("{}", c)),
         _ => Err(LispError::new(
             "codepoints expects one argument of type Char or String",
         )),

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -21,7 +21,7 @@ fn unescape(input: &str) -> String {
                 check = false;
             }
             _ if check => {
-                output.extend(&[b'\\', character]);
+                output.extend([b'\\', character]);
                 check = false;
             }
             _ => output.push(character),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -110,7 +110,7 @@ fn call_lambda_int(
         let mut tmp_eval: Option<Expression> = None;
         let last_eval = match body {
             MultiExpression::None => Expression::make_nil(),
-            MultiExpression::Single(body) => eval_nr(environment, &body)?,
+            MultiExpression::Single(body) => eval_nr(environment, body)?,
             MultiExpression::Multiple(body) => {
                 for arg in body {
                     if let Some(ret) = tmp_eval {

--- a/src/process.rs
+++ b/src/process.rs
@@ -135,7 +135,7 @@ fn run_command(
         }
         // If we still have procs running then maybe don't orphin them (at least not yet).
         if environment.procs.borrow().is_empty() {
-            return Err(exec(&command, &args).into());
+            return Err(exec(command, &args).into());
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -91,7 +91,7 @@ fn char_to_hex_num(ch: &str) -> Result<u8, ReadError> {
 fn escape_to_char(chars: &mut CharIter, reader_state: &mut ReaderState) -> Result<char, ReadError> {
     if let (Some(ch1), Some(ch2)) = (chars.next(), chars.next()) {
         reader_state.column += 1;
-        let ch_n: u8 = (char_to_hex_num(&*ch1)? * 16) + (char_to_hex_num(&*ch2)?);
+        let ch_n: u8 = (char_to_hex_num(&ch1)? * 16) + (char_to_hex_num(&ch2)?);
         if ch_n > 0x7f {
             Err(ReadError {
                 reason: "Invalid hex ascii code, must be less then \\x7f.".to_string(),
@@ -220,7 +220,7 @@ fn do_char(
             }
         }
         Ok(make_exp(
-            ExpEnum::Char(environment.interner.intern(&*ch).into()),
+            ExpEnum::Char(environment.interner.intern(&ch).into()),
             meta,
         ))
     } else {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -76,7 +76,7 @@ pub fn start_interactive(is_tty: bool) -> i32 {
     let mut hostname = [0_u8; 512];
     env::set_var(
         "HOST",
-        &gethostname(&mut hostname)
+        gethostname(&mut hostname)
             .ok()
             .map_or_else(|| "?".into(), CStr::to_string_lossy)
             .as_ref(),

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -184,7 +184,7 @@ impl Symbols {
         count
     }
 
-    pub fn insert_capture(&self, key: &'static str, environment: &mut Environment) -> usize {
+    pub fn insert_capture(&self, key: &'static str) -> usize {
         let mut data = self.data.borrow_mut();
         let count = data.count;
         data.syms.insert(key, count);
@@ -196,7 +196,7 @@ impl Symbols {
             // Also capture in outer lexical scope or bad things can happen.
             let outer = outer.borrow();
             if !outer.contains_symbol(key) {
-                outer.insert_capture(key, environment);
+                outer.insert_capture(key);
             }
         }
         count


### PR DESCRIPTION
patch to allow this script to work:

```
(pipe (syscall "ls" "-alh") (iterator::for l in stdin (print "line: " l)))
```