### PR TITLE
Test rust docs in rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +319,35 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ryu"
@@ -405,6 +449,8 @@ dependencies = [
  "chrono",
  "compile_state",
  "glob",
+ "lazy_static",
+ "regex",
  "shell",
  "sl-compiler",
  "sl-liner",

--- a/bridge_types/src/lib.rs
+++ b/bridge_types/src/lib.rs
@@ -72,11 +72,39 @@ pub struct Param {
 pub struct ErrorStrings {}
 
 impl ErrorStrings {
-    pub fn mismatched_type(fn_name: &str, expected: &str, got: &str) -> String {
-        format!("{fn_name}: mismatched type input, expected {expected}, got {got}.")
+    pub fn mismatched_type(
+        fn_name: impl AsRef<str>,
+        expected: impl AsRef<str>,
+        got: impl AsRef<str>,
+        additional: impl AsRef<str>,
+    ) -> String {
+        if additional.as_ref().is_empty() {
+            format!(
+                "{}: mismatched type input, expected value of type {}, got {}.",
+                fn_name.as_ref(),
+                expected.as_ref(),
+                got.as_ref(),
+            )
+        } else {
+            format!(
+                "{}: mismatched type input, expected value of type {}, got {}. {}",
+                fn_name.as_ref(),
+                expected.as_ref(),
+                got.as_ref(),
+                additional.as_ref(),
+            )
+        }
     }
 
-    pub fn fix_me_mismatched_type(expected: &str, got: &str) -> String {
-        Self::mismatched_type("fixme", expected, got)
+    pub fn fix_me_mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
+        Self::mismatched_type("fixme", expected, got, "")
+    }
+
+    pub fn fix_me_mismatched_type_with_context(
+        expected: impl AsRef<str>,
+        got: impl AsRef<str>,
+        additional: impl AsRef<str>,
+    ) -> String {
+        Self::mismatched_type("fixme", expected, got, additional)
     }
 }

--- a/builtins/src/io.rs
+++ b/builtins/src/io.rs
@@ -80,8 +80,7 @@ Section: io
         env,
         "fs-exists?",
         fs_exists,
-        r#"
- Usage: (fs-exists? path-to-test)
+        r#"Usage: (fs-exists? path-to-test)
 
 Does the given path exist?
 

--- a/builtins/src/types/numbers.rs
+++ b/builtins/src/types/numbers.rs
@@ -27,8 +27,29 @@ impl SlFrom<&Value> for i32 {
                 })
             }
             _ => Err(VMError::new_conversion(
-                ErrorStrings::fix_me_mismatched_type(ValueType::Int.into(), value.display_type(vm)),
+                ErrorStrings::fix_me_mismatched_type(
+                    <&'static str>::from(ValueType::Int),
+                    value.display_type(vm),
+                ),
             )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::types::SlInto;
+    use compile_state::state::new_slosh_vm;
+    use slvm::Value;
+
+    #[test]
+    fn test_i32_conversions_rust_to_value() {
+        let mut vm = new_slosh_vm();
+        let vm = &mut vm;
+        let test_vals = vec![0_i32, 1_i32, -1_i32, i32::MIN, i32::MAX];
+        for val in test_vals {
+            let val: Value = val.sl_into(vm).expect("i32 can be converted to Value");
+            assert!(matches!(val, Value::Int(_)));
         }
     }
 }

--- a/builtins/src/types/numbers.rs
+++ b/builtins/src/types/numbers.rs
@@ -37,10 +37,11 @@ impl SlFrom<&Value> for i32 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use crate::types::SlFrom;
     use crate::types::SlInto;
     use compile_state::state::new_slosh_vm;
-    use slvm::Value;
+    use slvm::{to_i56, Value};
 
     #[test]
     fn test_i32_conversions_rust_to_value() {
@@ -51,5 +52,13 @@ mod test {
             let val: Value = val.sl_into(vm).expect("i32 can be converted to Value");
             assert!(matches!(val, Value::Int(_)));
         }
+    }
+
+    #[test]
+    fn test_i32_conversions_value_to_rust() {
+        let mut vm = new_slosh_vm();
+        let vm = &mut vm;
+        let val = to_i56(7_i32 as i64);
+        let _val: i32 = i32::sl_from(&val, vm).expect("Value can be converted to i32");
     }
 }

--- a/builtins/src/types/string_char.rs
+++ b/builtins/src/types/string_char.rs
@@ -176,7 +176,7 @@ impl SlFrom<&Value> for String {
 
 //TODO PC finish testing negative cases e.g. asserting that errrors are thrown.
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::gensym;
     use crate::types::{SlAsMut, SlAsRef, SlFromRef, SlInto, SlIntoRef};

--- a/slosh/Cargo.toml
+++ b/slosh/Cargo.toml
@@ -16,6 +16,10 @@ shell = { path = "../shell" }
 unicode-width = "0.1"
 glob = "0.3"
 
+[dev-dependencies]
+regex = "1.10.2"
+lazy_static = "1.4.0"
+
 [build-dependencies]
 chrono = "0.4.7"
 

--- a/slosh/src/main.rs
+++ b/slosh/src/main.rs
@@ -488,7 +488,6 @@ mod tests {
     use std::collections::HashSet;
     use std::error::Error;
     use std::fmt::{Debug, Display, Formatter};
-    //use sl_compiler::test_utils::exec;
 
     lazy_static! {
         static ref DOC_REGEX: Regex =

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1,5 +1,4 @@
 use crate::{Handle, Heap, Interned, VMError, VMResult};
-use std::borrow::Cow;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -729,11 +728,5 @@ impl<const N: usize> From<ValueTypes<N>> for String {
             res.push_str(v);
         }
         res
-    }
-}
-
-impl<'a, const N: usize> From<ValueTypes<N>> for Cow<'a, str> {
-    fn from(value: ValueTypes<N>) -> Self {
-        Cow::Owned(String::from(value))
     }
 }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1,6 +1,5 @@
 use crate::{Handle, Heap, Interned, VMError, VMResult};
-use std::collections::hash_map::RandomState;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -715,7 +714,7 @@ impl<const N: usize> Deref for ValueTypes<N> {
 impl<const N: usize> From<ValueTypes<N>> for String {
     fn from(value: ValueTypes<N>) -> Self {
         let mut res = String::new();
-        let set: HashSet<&str, RandomState> = HashSet::from_iter(
+        let set: BTreeSet<&str> = BTreeSet::from_iter(
             value
                 .deref()
                 .iter()


### PR DESCRIPTION
- made a test that checks the format of rust docs, or at least, the strings the get-prop function gets for the :doc-string keywork
- migrated some docs over from sl-sh
- added some EXEMPTIONS


- did a bit of work with the ErrorStrings I'm basing my errors in the conversion lib functions.

main point was to get the docstrings in rust and make sure they were formatted correctly so if you break something in rust, cargo test tells you. obviously incomplete because of the EXEMPTIONS set but it is a start. Mainly a pre-cursor to me actually eval-ing the Example: sections for the docs that do have them.