### PR TITLE
feat: support for F56 56-bit floating point numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ https://sl-sh-dev.github.io/sl-sh/mydoc_api.html
 - Symbol
 - Keyword
 - Character (chars are grapheme clusters)
-- Float (32 bits- f32)
+- Float (56 bit float)
 - Integer (56 bit signed integer)
 - Byte
 

--- a/builtins/src/types/numbers.rs
+++ b/builtins/src/types/numbers.rs
@@ -116,9 +116,13 @@ mod tests {
     }
 
     #[test]
+    /// Declares a bunch of f64s meant to represent a wide range of values of various edge cases
+    /// Converts each f64 to f56 and back to f64 to see how it changes
+    /// If they are equal, then that conversion was successful
+    /// If they are unequal, then it may still be successful if the f64 was outside of the range that the F56 could represent
+    /// A debug function is provided to visually inspect the bytes of the f64, F56, and corresponding f32
+
     fn test_f56() {
-        /* For each of these test numbers, convert them from f64 to f56 and back and
-        verify that the number hasn't changed much */
         let numbers_to_test = [
             f64::from_bits(0x0000_0000_0000_0000u64),
             f64::from_bits(0x0000_0000_0000_0001u64),
@@ -247,32 +251,32 @@ mod tests {
 
         for index in 0..numbers_to_test.len() {
             let orig_f64 = numbers_to_test[index];
-            /* Calculate the values  */
+            // Calculate the values
             let f32 = orig_f64 as f32;
             let f56 = F56::from(orig_f64);
             let back_to_f64: f64 = f56.into();
             let f32_diff = ((f32 as f64) - orig_f64).abs();
             let f56_diff = (back_to_f64 - orig_f64).abs();
 
-            /* If the converted value equals the original, we passed the test */
+            // If the converted value equals the original, we passed the test
             if back_to_f64 == orig_f64 {
                 continue;
             }
 
-            /* Signs must match */
+            // Signs must match
             if orig_f64.is_sign_positive() != back_to_f64.is_sign_positive() {
                 debug(orig_f64, index);
                 panic!("Signs don't match");
             }
 
-            /* NaNs must match */
+            // NaNs must match
             if orig_f64.is_nan() != back_to_f64.is_nan() {
                 debug(orig_f64, index);
                 panic!("original f64 and f56 should either both be NaN or neither be NaN");
             }
 
-            /* Both must be finite or infinite
-            Unless the f64 is very large and the F56 is infinite */
+            // Both must be finite or infinite
+            // Unless the f64 is very large and the F56 is infinite
             if orig_f64.is_infinite() != back_to_f64.is_infinite() {
                 if orig_f64.is_infinite() {
                     debug(orig_f64, index);
@@ -286,9 +290,8 @@ mod tests {
                 }
                 continue; // Don't check magnitude of difference if one is infinite
             }
-            /* Both must be zero or nonzero
-            Unless the f64 is very small and the F56 is zero
-             */
+            // Both must be zero or nonzero
+            // Unless the f64 is very small and the F56 is zero
             if (orig_f64 == 0.0) != (back_to_f64 == 0.0) {
                 if orig_f64 == 0.0 {
                     debug(orig_f64, index);
@@ -303,14 +306,14 @@ mod tests {
                 continue;
             }
 
-            /* The absolute difference must be small
-            smaller than the difference between an f32 and the f64 */
+            // The absolute difference must be small
+            // smaller than the difference between an f32 and the f64
             if f56_diff > f32_diff {
                 debug(orig_f64, index);
                 panic!("f56 is less accurate than the f32 conversion");
             }
 
-            /* The relative difference must be less than F56's EPSILON */
+            // The relative difference must be less than F56's EPSILON
             let relative_difference = f56_diff / orig_f64.abs();
             if relative_difference > F56::EPSILON {
                 debug(orig_f64, index);

--- a/builtins/src/types/numbers.rs
+++ b/builtins/src/types/numbers.rs
@@ -41,7 +41,60 @@ mod tests {
     use crate::types::SlFrom;
     use crate::types::SlInto;
     use compile_state::state::new_slosh_vm;
+    use core::panic;
+    use slvm::F56;
     use slvm::{to_i56, Value};
+
+    pub fn log_f32(f: f32) -> String {
+        let bytes = f.to_be_bytes();
+        let word = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let f32_biased_exponent: u8 = (word >> 23) as u8; // first 8 bits after the sign bit
+        let mut true_exponent: i16 = (f32_biased_exponent as i16) - 127; // remove the bias of 2^7-1
+        if f32_biased_exponent == 0 {
+            true_exponent = 0;
+        }
+        let f32_mantissa = word & 0x007f_ffff; // everything after first 9 bits
+                                               // print the f32 in scientific notation, the true exponent in decimal, and the mantissa in decimal, and the hex word
+        format!(
+            "f32: {:.5e}, true exponent: {}, mantissa: {:016x}, word: {:016x}",
+            f, true_exponent, f32_mantissa, word
+        )
+    }
+    pub fn log_f56(f: F56) -> String {
+        let bytes7 = f.0;
+        let word = u64::from_be_bytes([
+            0, bytes7[0], bytes7[1], bytes7[2], bytes7[3], bytes7[4], bytes7[5], bytes7[6],
+        ]);
+        let f56_biased_exponent: u16 = ((word >> 45) as u16) & 0x3FF; // first 10 bits after the sign bit
+        let f56_mantissa = word & 0x1FFFF_FFFF_FFFF; // everything after first 10 bits
+        let mut true_exponent = f56_biased_exponent as i16 - 511; // remove the bias of 2^9-1
+        if f56_biased_exponent == 0 {
+            true_exponent = 0;
+        }
+        format!(
+            "f56: {:.5e}, true exponent: {}, mantissa: {:016x}, word: {:016x}",
+            f64::from(f),
+            true_exponent,
+            f56_mantissa,
+            word
+        )
+    }
+    pub fn log_f64(f: f64) -> String {
+        let bytes = f.to_be_bytes();
+        let word = u64::from_be_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ]);
+        let f64_biased_exponent: i16 = ((word & 0x7ff0_0000_0000_0000) >> 52) as i16; // first 11 bits after the sign bit
+        let mut true_exponent: i16 = f64_biased_exponent - 1023; // remove the bias of 2^10-1
+        if f64_biased_exponent == 0 {
+            true_exponent = 0;
+        }
+        let f64_mantissa = word & 0x001f_ffff_ffff_ffff; // everything after first 11 bits
+        format!(
+            "f64: {:.5e}, true exponent: {}, mantissa: {:016x}, word: {:016x}",
+            f, true_exponent, f64_mantissa, word
+        )
+    }
 
     #[test]
     fn test_i32_conversions_rust_to_value() {
@@ -60,5 +113,213 @@ mod tests {
         let vm = &mut vm;
         let val = to_i56(7_i32 as i64);
         let _val: i32 = i32::sl_from(&val, vm).expect("Value can be converted to i32");
+    }
+
+    #[test]
+    fn test_f56() {
+        /* For each of these test numbers, convert them from f64 to f56 and back and
+        verify that the number hasn't changed much */
+        let numbers_to_test = [
+            f64::from_bits(0x0000_0000_0000_0000u64),
+            f64::from_bits(0x0000_0000_0000_0001u64),
+            f64::from_bits(0x8000_0000_0000_0000u64),
+            f64::from_bits(0x7FFF_FFFF_FFFF_FFFFu64),
+            f64::from_bits(0x7FFF_FFFF_FFFF_FFFEu64),
+            f64::from_bits(0xFFFF_FFFF_FFFF_FFFFu64),
+            f64::from_bits(0x7000_0000_0000_0000u64),
+            f64::from_bits(0xDEAD_BEEF_DEAD_BEEFu64),
+            f64::from_bits(0x1234_5678_9ABC_DEF0u64),
+            f64::from_bits(0x1111_1111_1111_1111u64),
+            f64::from_bits(0x2222_2222_2222_2222u64),
+            f64::from_bits(0x3333_3333_3333_3333u64),
+            f64::from_bits(0x4444_4444_4444_4444u64),
+            f64::from_bits(0x5555_5555_5555_5555u64),
+            f64::from_bits(0x6666_6666_6666_6666u64),
+            f64::from_bits(0x7777_7777_7777_7777u64),
+            f64::from_bits(0x8888_8888_8888_8888u64),
+            f64::from_bits(0x9999_9999_9999_9999u64),
+            f64::from_bits(0xAAAA_AAAA_AAAA_AAAAu64),
+            f64::from_bits(0xBBBB_BBBB_BBBB_BBBBu64),
+            f64::from_bits(0xCCCC_CCCC_CCCC_CCCCu64),
+            f64::from_bits(0xDDDD_DDDD_DDDD_DDDDu64),
+            f64::from_bits(0xEEEE_EEEE_EEEE_EEEEu64),
+            f64::from_bits(0xFFFF_FFFF_FFFF_FFFEu64),
+            f64::from_bits(0xFFF0_0000_0000_0001u64),
+            0x0000_0000_0000_0000u64 as f64,
+            0x0000_0000_0000_0001u64 as f64,
+            0x8000_0000_0000_0000u64 as f64,
+            0x7FFF_FFFF_FFFF_FFFFu64 as f64,
+            0x7FFF_FFFF_FFFF_FFFEu64 as f64,
+            0xFFFF_FFFF_FFFF_FFFFu64 as f64,
+            0x7000_0000_0000_0000u64 as f64,
+            0xDEAD_BEEF_DEAD_BEEFu64 as f64,
+            0x1234_5678_9ABC_DEF0u64 as f64,
+            0x1111_1111_1111_1111u64 as f64,
+            0x2222_2222_2222_2222u64 as f64,
+            0x3333_3333_3333_3333u64 as f64,
+            0x4444_4444_4444_4444u64 as f64,
+            0x5555_5555_5555_5555u64 as f64,
+            0x6666_6666_6666_6666u64 as f64,
+            0x7777_7777_7777_7777u64 as f64,
+            0x8888_8888_8888_8888u64 as f64,
+            0x9999_9999_9999_9999u64 as f64,
+            0xAAAA_AAAA_AAAA_AAAAu64 as f64,
+            0xBBBB_BBBB_BBBB_BBBBu64 as f64,
+            0xCCCC_CCCC_CCCC_CCCCu64 as f64,
+            0xDDDD_DDDD_DDDD_DDDDu64 as f64,
+            0xEEEE_EEEE_EEEE_EEEEu64 as f64,
+            0xFFFF_FFFF_FFFF_FFFEu64 as f64,
+            0xFFF0_0000_0000_0001u64 as f64,
+            0.0,
+            -0.0,
+            2.3,
+            23.0,
+            230.0,
+            2300.0,
+            23000.0,
+            230000.0,
+            23e5,
+            23e6,
+            2.3e5,
+            0.23,
+            0.023,
+            0.0023,
+            0.00023,
+            0.000023,
+            0.0000023,
+            0.23e-5,
+            f32::MIN_POSITIVE as f64, // 42
+            f32::MIN_POSITIVE as f64 / 3.0,
+            f32::MIN_POSITIVE as f64 / 7e5,
+            f32::MIN_POSITIVE as f64 / 7e6,
+            f32::MIN_POSITIVE as f64 / 7e7,
+            f32::MIN_POSITIVE as f64 / 7e8,
+            f32::MIN_POSITIVE as f64 / 4.123e14,
+            f32::MAX as f64,
+            f32::MAX as f64 * 3.0,
+            f32::MAX as f64 + 99.0,
+            f64::MIN_POSITIVE,
+            f64::MIN_POSITIVE / 2.0,
+            f64::MIN_POSITIVE / 10.0,
+            f64::MIN,
+            f64::MAX,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+            F56::EPSILON,
+            F56::EPSILON / 3.0,
+            f64::from(F56::MAX),
+            f64::from(F56::MAX) + 1.0,
+            f64::from(F56::MIN_POSITIVE),
+            f64::from(F56::MIN_POSITIVE) / 3.0, // #55
+            f64::from(F56::MIN_POSITIVE_SUBNORMAL),
+            f64::from(F56::MIN_POSITIVE_SUBNORMAL) / 3.0,
+            -f64::from(F56::MAX),
+            -f64::from(F56::MAX) - 1.0,
+            -f64::from(F56::MAX) * 3.3,
+            8.4e-168,
+            8.4e-169,
+            8.4e-170,
+        ];
+
+        fn debug(orig_f64: f64, index: usize) {
+            println!("index: {}", index);
+            println!("original f64      : {}", log_f64(orig_f64));
+            println!("f64 -> f32        : {}", log_f32(orig_f64 as f32));
+            println!("f64 -> f32 -> f64 : {}", log_f64((orig_f64 as f32) as f64));
+            println!("f64 -> f56        : {}", log_f56(F56::from(orig_f64)));
+            println!(
+                "f64 -> f56 -> f64 : {}",
+                log_f64(f64::from(F56::from(orig_f64)))
+            );
+            let f32_diff = (f64::from(orig_f64 as f32) - orig_f64).abs();
+            let f32_relative_difference = f32_diff / orig_f64.abs();
+            if f32_relative_difference > 0.0 {
+                println!("f32 relative difference {:.5e}", f32_relative_difference);
+            }
+            let f56_diff: f64 = (f64::from(F56::from(orig_f64)) - orig_f64).abs();
+            let f56_relative_difference = f56_diff / orig_f64.abs();
+            if f56_relative_difference > 0.0 {
+                println!("f56 relative difference {:.5e}", f56_relative_difference);
+            }
+            println!("")
+        }
+
+        for index in 0..numbers_to_test.len() {
+            let orig_f64 = numbers_to_test[index];
+            /* Calculate the values  */
+            let f32 = orig_f64 as f32;
+            let f56 = F56::from(orig_f64);
+            let back_to_f64: f64 = f56.into();
+            let f32_diff = ((f32 as f64) - orig_f64).abs();
+            let f56_diff = (back_to_f64 - orig_f64).abs();
+
+            /* If the converted value equals the original, we passed the test */
+            if back_to_f64 == orig_f64 {
+                continue;
+            }
+
+            /* Signs must match */
+            if orig_f64.is_sign_positive() != back_to_f64.is_sign_positive() {
+                debug(orig_f64, index);
+                panic!("Signs don't match");
+            }
+
+            /* NaNs must match */
+            if orig_f64.is_nan() != back_to_f64.is_nan() {
+                debug(orig_f64, index);
+                panic!("original f64 and f56 should either both be NaN or neither be NaN");
+            }
+
+            /* Both must be finite or infinite
+            Unless the f64 is very large and the F56 is infinite */
+            if orig_f64.is_infinite() != back_to_f64.is_infinite() {
+                if orig_f64.is_infinite() {
+                    debug(orig_f64, index);
+                    panic!("f56 should be infinite when original f64 is infinite");
+                } else if back_to_f64.is_infinite() {
+                    if orig_f64.abs() < f64::from(F56::MAX) {
+                        debug(orig_f64, index);
+                        println!("F56::MAX: {:.2e}", f64::from(F56::MAX));
+                        panic!("f56 should be finite if original f64 is between -F56::MAX and +F56::MAX");
+                    }
+                }
+                continue; // Don't check magnitude of difference if one is infinite
+            }
+            /* Both must be zero or nonzero
+            Unless the f64 is very small and the F56 is zero
+             */
+            if (orig_f64 == 0.0) != (back_to_f64 == 0.0) {
+                if orig_f64 == 0.0 {
+                    debug(orig_f64, index);
+                    panic!("f56 should be zero when original f64 is zero");
+                } else if orig_f64.abs() > f64::from(F56::MIN_POSITIVE) {
+                    debug(orig_f64, index);
+                    panic!(
+                        "f56 should be zero when abs(original f64) < F56::MIN_POSITIVE_SUBNORMAL ({})",
+                        f64::from(F56::MIN_POSITIVE_SUBNORMAL)
+                    );
+                }
+                continue;
+            }
+
+            /* The absolute difference must be small
+            smaller than the difference between an f32 and the f64 */
+            if f56_diff > f32_diff {
+                debug(orig_f64, index);
+                panic!("f56 is less accurate than the f32 conversion");
+            }
+
+            /* The relative difference must be less than F56's EPSILON */
+            let relative_difference = f56_diff / orig_f64.abs();
+            if relative_difference > F56::EPSILON {
+                debug(orig_f64, index);
+                panic!(
+                    "f56 is less accurate than it should be. relative difference: {}, max: {}",
+                    relative_difference,
+                    F56::EPSILON
+                );
+            }
+        }
     }
 }

--- a/shell/src/command_data.rs
+++ b/shell/src/command_data.rs
@@ -208,7 +208,6 @@ impl RedirType {
                     .append(true)
                     .create(true)
                     .read(true)
-                    .write(true)
                     .open(path)?;
                 // Use as_raw_fd ot nto_raw_fd so f will close when dropped.
                 Sys::dup2_fd(f.into(), *fd)?;

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -107,19 +107,21 @@ pub struct F56(pub [u8; 7]);
 impl Eq for F56 {}
 impl PartialEq for F56 {
     fn eq(&self, other: &Self) -> bool {
+        let self_as_f64 = f64::from(*self);
+        let other_as_f64 = f64::from(*other);
         // Allow NaN == NaN so equality is reflexive and we can impl Eq to use F56 as a hash key
-        if f64::from(*self).is_nan() && f64::from(*other).is_nan() {
+        if self_as_f64.is_nan() && other_as_f64.is_nan() {
             return true;
         };
         // Round to nearest multiple of F56::EPSILON for equality test
         // Note how this is different from testing that the difference between the two is less than F56::EPSILON
         // But this is necessary to guarantee that a == b => hash(a) == hash(b)
         let precision = 1.0 / F56::EPSILON;
-        let value = f64::from(*self);
-        let rounded = (value * precision).round() / precision;
-        let other_value = f64::from(*other);
-        let other_rounded = (other_value * precision).round() / precision;
-        rounded == other_rounded
+        // since we are just comparing the values, we don't actually need to calculate the rounded value
+        // so we can omit the last step to divide by precision from both sides
+        let self_scaled = (self_as_f64 * precision).round();
+        let other_scaled = (other_as_f64 * precision).round();
+        self_scaled == other_scaled
     }
 }
 impl Hash for F56 {

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -253,13 +253,13 @@ impl From<F56> for f64 {
         let f64_biased_exponent: u64 = match { f56_biased_exponent } {
             0b11_1111_1111 => {
                 // Special case of all [1]s meaning NaN or Infinity
-                0b111_1111_1111 as u64
+                0b111_1111_1111_u64
             }
             0b00_0000_0000 => {
                 // Special case of all [0]s meaning 0 or subnormal
                 if f56_mantissa == 0u64 {
                     // the f56 was 0 so the f64 should be 0
-                    0b000_0000_0000 as u64
+                    0b000_0000_0000_u64
                 } else {
                     // the f56 was subnormal so the f64 should interpret the exponent as -512
                     // note the slightly different addition of 1022 instead of 1023
@@ -276,7 +276,7 @@ impl From<F56> for f64 {
         };
 
         let f64_sign = f56_sign as u64;
-        let f64_mantissa = f56_mantissa << 7 as u64; // we add 7 bits in mantissa, but they're all zeros
+        let f64_mantissa = f56_mantissa << 7_u64; // we add 7 bits in mantissa, but they're all zeros
         let word: u64 = f64_sign << 63 | f64_biased_exponent << 52 | f64_mantissa;
         f64::from_be_bytes(word.to_be_bytes())
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -250,7 +250,7 @@ impl From<F56> for f64 {
         let f56_mantissa: u64 = f56_word & 0x1FFF_FFFF_FFFF; // the rightmost 45 bits
         let true_exponent = f56_biased_exponent as i16 - 511; // remove the bias of 2^9-1
 
-        let f64_biased_exponent: u64 = match { f56_biased_exponent } {
+        let f64_biased_exponent: u64 = match f56_biased_exponent {
             0b11_1111_1111 => {
                 // Special case of all [1]s meaning NaN or Infinity
                 0b111_1111_1111_u64

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -457,11 +457,11 @@ impl Value {
         }
     }
 
-    pub fn get_float<ENV>(&self, _vm: &GVm<ENV>) -> VMResult<f32> {
+    pub fn get_float<ENV>(&self, _vm: &GVm<ENV>) -> VMResult<f64> {
         match &self {
-            Value::Byte(b) => Ok(*b as f32),
-            Value::Int(i) => Ok(from_i56(i) as f32),
-            Value::Float(f) => Ok(f32::from(*f)),
+            Value::Byte(b) => Ok(*b as f64),
+            Value::Int(i) => Ok(from_i56(i) as f64),
+            Value::Float(f) => Ok(f64::from(*f)),
             _ => Err(VMError::new_value(format!("Not a float: {self:?}"))),
         }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     from_i56, CallFrame, CallFunc, CallFuncSig, Chunk, Globals, Handle, Heap, Interner, VMError,
-    VMErrorObj, VMResult, Value, HALT,
+    VMErrorObj, VMResult, Value, F56, HALT,
 };
 
 mod cons;
@@ -220,7 +220,7 @@ impl<ENV> GVm<ENV> {
                 val = Value::True;
             }
         } else if val1.is_number() && val2.is_number() {
-            if (val1.get_float(self)? - val2.get_float(self)?).abs() < f32::EPSILON {
+            if (val1.get_float(self)? - val2.get_float(self)?).abs() < F56::EPSILON {
                 val = Value::True;
             }
         } else {
@@ -911,7 +911,9 @@ mod tests {
         let chunk = Arc::new(chunk);
         vm.execute(chunk)?;
         let result = vm.stack(5).get_float(&vm)?;
-        assert!(result == 12500.0);
+
+        // NOTE: converting the result to f32 because the f64 expects more precision than our F56 can provide.
+        assert_eq!(result as f32, 12500.0);
 
         Ok(())
     }

--- a/vm/src/vm/macros.rs
+++ b/vm/src/vm/macros.rs
@@ -169,9 +169,9 @@ macro_rules! get_int {
 macro_rules! get_float {
     ($vm:expr, $val:expr) => {{
         match $val {
-            $crate::Value::Byte(b) => Ok(b as f32),
-            $crate::Value::Int(i) => Ok(crate::from_i56(&i) as f32),
-            $crate::Value::Float(f) => Ok(f.0),
+            $crate::Value::Byte(b) => Ok(b as f64),
+            $crate::Value::Int(i) => Ok(crate::from_i56(&i) as f64),
+            $crate::Value::Float(f) => Ok(f64::from(f)),
             _ => Err($crate::VMError::new_value(format!(
                 "Not a float: {:?}",
                 $val
@@ -187,11 +187,12 @@ macro_rules! binary_math {
         let op2 = $vm.register(op2 as usize);
         match (op1, op2) {
             ($crate::Value::Float(op1_f), $crate::Value::Float(op2_f)) => {
-                *$vm.register_mut(dest as usize) = $bin_fn(op1_f.0, op2_f.0).into();
+                *$vm.register_mut(dest as usize) =
+                    $bin_fn(f64::from(op1_f), f64::from(op2_f)).into();
             }
             ($crate::Value::Float(op1_f), _) => {
                 *$vm.register_mut(dest as usize) = $bin_fn(
-                    op1_f.0,
+                    f64::from(op1_f),
                     get_float!($vm, op2).map_err(|e| (e, $chunk.clone()))?,
                 )
                 .into();
@@ -199,7 +200,7 @@ macro_rules! binary_math {
             (_, $crate::Value::Float(op2_f)) => {
                 *$vm.register_mut(dest as usize) = $bin_fn(
                     get_float!($vm, op1).map_err(|e| (e, $chunk.clone()))?,
-                    op2_f.0,
+                    f64::from(op2_f),
                 )
                 .into();
             }
@@ -221,24 +222,24 @@ macro_rules! div_math {
         let op2 = $vm.register(op2 as usize);
         match (op1, op2) {
             ($crate::Value::Float(op1_f), $crate::Value::Float(op2_f)) => {
-                let op1 = op1_f.0;
-                let op2 = op2_f.0;
+                let op1 = f64::from(op1_f);
+                let op2 = f64::from(op2_f);
                 if op2 == 0.0 {
                     return Err(($crate::VMError::new_vm("Divide by zero error."), $chunk));
                 }
                 *$vm.register_mut(dest as usize) = (op1 / op2).into();
             }
             ($crate::Value::Float(op1_f), _) => {
-                let op1 = op1_f.0;
-                let op2 = get_float!($vm, op2).map_err(|e| (e, $chunk.clone()))? as f32;
+                let op1 = f64::from(op1_f);
+                let op2 = get_float!($vm, op2).map_err(|e| (e, $chunk.clone()))? as f64;
                 if op2 == 0.0 {
                     return Err(($crate::VMError::new_vm("Divide by zero error."), $chunk));
                 }
                 *$vm.register_mut(dest as usize) = (op1 / op2).into();
             }
             (_, $crate::Value::Float(op2_f)) => {
-                let op1 = get_float!($vm, op1).map_err(|e| (e, $chunk.clone()))? as f32;
-                let op2 = op2_f.0;
+                let op1 = get_float!($vm, op1).map_err(|e| (e, $chunk.clone()))? as f64;
+                let op2 = f64::from(op2_f);
                 if op2 == 0.0 {
                     return Err(($crate::VMError::new_vm("Divide by zero error."), $chunk));
                 }


### PR DESCRIPTION
### Overview
This implementation allows us to store floats with greater precision.
The existing implementation stores `slvm::Value::Float` as a wrapped `f32` and ignores the other 3 available bytes.

### Changes
- `builtins/src/types/numbers.rs` primarily just has the new test cases (100 of them!)
- `vm/src/value.rs` has the actual `F56` implementation and some changes from the previous implementation using `F32Wrap`
- `vm/src/vm/macros.rs` might require some additional attention. The `get_float` macro here is now set to operate on `f64` types. But a similar `get_float` macro in `value.rs` is set to `f32`.  These implications should be explored.
