### PR TITLE
Make -c work with strings of lisp code.

### DIFF
--- a/shell/src/command_data.rs
+++ b/shell/src/command_data.rs
@@ -208,7 +208,6 @@ impl RedirType {
                     .append(true)
                     .create(true)
                     .read(true)
-                    .write(true)
                     .open(path)?;
                 // Use as_raw_fd ot nto_raw_fd so f will close when dropped.
                 Sys::dup2_fd(f.into(), *fd)?;

--- a/slosh/src/main.rs
+++ b/slosh/src/main.rs
@@ -399,15 +399,22 @@ fn main() {
             if Sys::is_tty(STDIN_FILENO) {
                 shell::run::setup_shell_tty(STDIN_FILENO);
             }
-            let status = SHELL_ENV.with(|jobs| {
-                match shell::run::run_one_command(&command, &mut jobs.borrow_mut()) {
-                    Ok(status) => status,
-                    Err(err) => {
-                        eprintln!("ERROR executing {command}: {err}");
-                        1
+            let status = if command.trim_start().starts_with('(') {
+                ENV.with(|env| {
+                    exec_expression(command, &mut env.borrow_mut());
+                });
+                0
+            } else {
+                SHELL_ENV.with(|jobs| {
+                    match shell::run::run_one_command(&command, &mut jobs.borrow_mut()) {
+                        Ok(status) => status,
+                        Err(err) => {
+                            eprintln!("ERROR executing {command}: {err}");
+                            1
+                        }
                     }
-                }
-            });
+                })
+            };
             SHELL_ENV.with(|jobs| {
                 jobs.borrow_mut().reap_procs();
             });


### PR DESCRIPTION
Simple fix for starting slosh with -c and a string of lisp code to execute.

This is pretty straightforward.  It does require using quotes to pass it as a string otherwise the shell will interpret the parens as a subshell request.  Need to push the boundaries on the shell/lisp reader interaction...