### PR TITLE
Float bencher update

### DIFF
--- a/slosh/benches/all.rs
+++ b/slosh/benches/all.rs
@@ -76,7 +76,7 @@ pub fn get_float_benchmark() -> PathBuf {
     get_benches_directory().join("float-bench.slosh")
 }
 
-fn run_float_script(n: usize, m: f32, expected: f32) {
+fn run_float_script(n: usize, m: f32, expected: f64) {
     let vm = &mut new_slosh_vm();
     let fname = get_float_benchmark();
     match std::fs::File::open(&fname) {
@@ -92,7 +92,7 @@ fn run_float_script(n: usize, m: f32, expected: f32) {
     let last = run_reader(&mut reader);
     match last {
         Ok(Value::Float(f)) => {
-            assert_eq!(f.0, expected);
+            assert_eq!(f64::from(f), expected);
         }
         _ => {
             panic!("Not a float");
@@ -106,15 +106,15 @@ mod instruction_count {
     use iai::{black_box, main};
 
     fn float_one_hundred() {
-        black_box(run_float_script(100, 0.5, 400.0));
+        black_box(run_float_script(100, 0.5, 399.99999999958527));
     }
 
     fn float_one_thousand() {
-        black_box(run_float_script(1000, 0.05, 2105.2483));
+        black_box(run_float_script(1000, 0.05, 2105.2631578924484));
     }
 
     fn float_ten_thousand() {
-        black_box(run_float_script(10_000, 0.2, 25000.0));
+        black_box(run_float_script(10_000, 0.2, 24999.999999998603));
     }
 
     main!(float_one_hundred, float_one_thousand, float_ten_thousand,);
@@ -131,19 +131,19 @@ mod wall_clock {
 
     fn float_one_hundred(c: &mut Criterion) {
         c.bench_function("float_ten", |bench| {
-            bench.iter(|| std::hint::black_box(run_float_script(100, 0.5, 400.0)));
+            bench.iter(|| std::hint::black_box(run_float_script(100, 0.5, 399.99999999958527)));
         });
     }
 
     fn float_one_thousand(c: &mut Criterion) {
         c.bench_function("float_one_thousand", |bench| {
-            bench.iter(|| std::hint::black_box(run_float_script(1000, 0.05, 2105.2483)));
+            bench.iter(|| std::hint::black_box(run_float_script(1000, 0.05, 2105.2631578924484)));
         });
     }
 
     fn float_ten_thousand(c: &mut Criterion) {
         c.bench_function("float_one_hundred", |bench| {
-            bench.iter(|| std::hint::black_box(run_float_script(10_000, 0.2, 25000.0)));
+            bench.iter(|| std::hint::black_box(run_float_script(10_000, 0.2, 24999.999999998603)));
         });
     }
 

--- a/slosh/benches/bench.slosh
+++ b/slosh/benches/bench.slosh
@@ -4,11 +4,11 @@
 
 (def pu (eval-pol 100 0.5))
 (prn "(eval-pol 100 0.5) =>\n" pu)
-(prn "passed: " (equal? pu 399.999999999585))
+(prn "passed: " (equal? pu 399.99999999958527))
 
 (def pu (eval-pol 1000 0.05))
 (prn "(eval-pol 1000 0.05) =>\n" pu)
-(prn "passed: " (equal? pu 2105.263157892448))
+(prn "passed: " (equal? pu 2105.2631578924484))
 
 (def pu (eval-pol 10000 0.2))
 (prn "(eval-pol 10000 0.2) =>\n" pu)

--- a/slosh/benches/bench.slosh
+++ b/slosh/benches/bench.slosh
@@ -4,13 +4,13 @@
 
 (def pu (eval-pol 100 0.5))
 (prn "(eval-pol 100 0.5) =>\n" pu)
-(assert-equal pu 400.0)
+(prn "passed: " (equal? pu 399.999999999585))
 
 (def pu (eval-pol 1000 0.05))
 (prn "(eval-pol 1000 0.05) =>\n" pu)
-(assert-equal pu 2105.2483)
+(prn "passed: " (equal? pu 2105.263157892448))
 
 (def pu (eval-pol 10000 0.2))
 (prn "(eval-pol 10000 0.2) =>\n" pu)
-(assert-equal pu 25000.0)
+(prn "passed: " (equal? pu 24999.999999998603))
 


### PR DESCRIPTION
@StevenLove even though the first two calls to eval-pol print out numbers in a given precision:
`399.999999999585` 
even though the correct answer as input by the program and correctly passed was: `399.99999999958527`


```
λ⸨⚙ ⸩ → ./bench.slosh
slosh 0.10.0 (test-new-floats:cee5608+, debug build, macos [aarch64], Feb 28 2024, 05:16:07 UTC [rustc 1.76.0 (07dca489a 2024-02-04)])
Using default slshrc written to "~/.config/slosh/init.slosh".
Edit this file to remove this message and customize your shell
(eval-pol 100 0.5) =>
399.999999999585
passed: true
(eval-pol 1000 0.05) =>
2105.263157892448
passed: true
(eval-pol 10000 0.2) =>
24999.999999998603
passed: true
```

is the printing working properly? Proof of issue is essentially 
1.  prints
```(eval-pol 100 0.5) =>
399.999999999585```
2 but
```(equal? (eval-pol 100 0.5) 399.999999999585)```
is false