### PR TITLE
3. added two trybuild tests and their accompanying errors that demonstrate an issue I'm having

### DIFF
--- a/builtins/trybuild/tests/borrow_checker_immut_mut_fail.rs
+++ b/builtins/trybuild/tests/borrow_checker_immut_mut_fail.rs
@@ -1,0 +1,14 @@
+use bridge_adapters::lisp_adapters::{SlAsRef, SlInto};
+use compile_state::state::new_slosh_vm;
+
+pub fn main() {}
+fn borrow_check() {
+    let mut vm = new_slosh_vm();
+    let dest = vm.alloc_string("XXX".to_string());
+    let dest2 = vm.alloc_string("YYY".to_string());
+
+    let y: &str = (&dest2).sl_as_ref(&vm).unwrap();
+    let x: String = (&dest).sl_into(&mut vm).unwrap();
+    println!("y: {}", y);
+    println!("x: {}", x);
+}

--- a/builtins/trybuild/tests/borrow_checker_immut_mut_fail.stderr
+++ b/builtins/trybuild/tests/borrow_checker_immut_mut_fail.stderr
@@ -1,0 +1,9 @@
+error[E0502]: cannot borrow `vm` as mutable because it is also borrowed as immutable
+  --> trybuild/tests/borrow_checker_immut_mut_fail.rs:11:37
+   |
+10 |     let y: &str = (&dest2).sl_as_ref(&vm).unwrap();
+   |                                      --- immutable borrow occurs here
+11 |     let x: String = (&dest).sl_into(&mut vm).unwrap();
+   |                                     ^^^^^^^ mutable borrow occurs here
+12 |     println!("y: {}", y);
+   |                       - immutable borrow later used here

--- a/builtins/trybuild/tests/borrow_checker_two_mut_fail.rs
+++ b/builtins/trybuild/tests/borrow_checker_two_mut_fail.rs
@@ -1,0 +1,27 @@
+use compile_state::state::new_slosh_vm;
+use slvm::Value;
+
+pub fn main() {}
+fn borrow_check() {
+    let mut vm = new_slosh_vm();
+    let dest = vm.alloc_string("XXX".to_string());
+    let dest2 = vm.alloc_string("YYY".to_string());
+    match dest {
+        Value::String(d) => {
+            let d = vm.get_string_mut(d).unwrap();
+            match dest2 {
+                Value::String(d2) => {
+                    let d2 = vm.get_string_mut(d2).unwrap();
+                    println!("x: {}", d);
+                    println!("y: {}", d2);
+                }
+                _ => {
+                    panic!("failed");
+                }
+            }
+        }
+        _ => {
+            panic!("failed");
+        }
+    }
+}

--- a/builtins/trybuild/tests/borrow_checker_two_mut_fail.stderr
+++ b/builtins/trybuild/tests/borrow_checker_two_mut_fail.stderr
@@ -1,0 +1,10 @@
+error[E0499]: cannot borrow `vm` as mutable more than once at a time
+  --> trybuild/tests/borrow_checker_two_mut_fail.rs:14:30
+   |
+11 |             let d = vm.get_string_mut(d).unwrap();
+   |                     -- first mutable borrow occurs here
+...
+14 |                     let d2 = vm.get_string_mut(d2).unwrap();
+   |                              ^^ second mutable borrow occurs here
+15 |                     println!("x: {}", d);
+   |                                       - first borrow later used here


### PR DESCRIPTION
because the SloshVm needs to be mutable to do allocations etc. I have run into an issue I demonstrated in the two test cases and their compile errors. Basically, I have to pull variables out of their value types into actual rust types so they can be manipulated by the target functions. Both tests are examples of behavior that might need to happen inside my macro.

Now this does mean that If I have a function that accepts 
```
#[sl_sh_fn("myfn")]
fn myfn(s1: &str, s2: &str, s3: &str) { ... }
```
I'll be fine because I can have as many immutable references to the vm as I want
```
let s1: &str = (&s1).sl_as_ref(&vm).unwrap();
let s2: &str = (&s2).sl_as_ref(&vm).unwrap();
let s3: &str = (&s3).sl_as_ref(&vm).unwrap();
myfn(s1, s2, s3); // I'm actually inlining myfn but this gets my point across.
```

here the mutable reference given to sl_into, the vm,  isn't tied to the lifetime it returns, so we can have as many of these references.
```
#[sl_sh_fn("myfn")]
fn myvaluefn(s1: String, s2: String, s3: String) { ... }
```
b
```
let s1: String = (&s1).sl_into(&vm).unwrap();
let s2: String = (&s2).sl_into(&vm).unwrap();
let s3: String = (&s3).sl_into(&vm).unwrap();
myvaluefn(s1, s2, s3); // I'm actually inlining myfn but this gets my point across.
```

it just looks like if you want to do something like:
```fn mymut(s1: &mut String, s2: &mut String)```
won't work because you can't get two mutable rust string types from the vm at the same time.

or in the other example
```fn myval_and_ref(s1: String, s2: &str)```
won't work because you'll already have a mutable and immutable from vm to have attained s1, and s2, 



SO. the limitation unless we do some unsafe/change &mut SloshVm requirement we won't be able to write rust functions that mix references and non references (all values, or all references... which might be fine), a function that needs mutable access to something the vm provides will only be able to accept one mutable argument.