### PR TITLE
a com-pilation-promise

### DIFF
--- a/slosh/benches/all.rs
+++ b/slosh/benches/all.rs
@@ -152,7 +152,7 @@ fn run_continuation_search_script(n: usize) {
     run_bench_assert_true(n, run_continuation_search_bench, vm);
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(target_os = "linux")]
 mod instruction_count {
     use super::*;
     use iai_callgrind::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
@@ -225,7 +225,7 @@ mod instruction_count {
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(target_os = "macos")]
 mod wall_clock {
     use super::*;
     use criterion::{criterion_group, criterion_main, Criterion};
@@ -305,9 +305,9 @@ mod wall_clock {
 }
 
 fn main() {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_os = "macos")]
     instruction_count::run_public();
 
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(target_os = "macos")]
     wall_clock::run();
 }


### PR DESCRIPTION
fortunately i'm running an arm computer. unfortunately it's still running the mac os.

@StevenLove  is also running mac, but with the intel arch.

and @sstanfield  i think you're on intel/linux.

since we can't easily get valgrind on mac, which is a requirement for iai-callgrind. I wanted to base it off os instead of architecture.

this does mean though @sstanfield that if you want to run the benchmarks that measure latency you'll have to mess with the cfg declaration in all.rs 

why would you ever need to run the criterion based tests. well. the `sl-py` repo that houses the python eval pol implementation (`pipenv run pytest --benchmark-json results.json benchmarks.py`) only runs latency tests. I don't see a python framework that supports the instruction/ram/l1 style enabled by valgrind.


that ok?