### PR TITLE
Implement clojure-style equality with =, not=, ==, and identical?

### DIFF
--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -379,7 +379,6 @@ Example:
 (test::assert-equal 0 (+))
 (test::assert-equal 5 (+ 5))
 (test::assert-equal 10 (+ 5 5))
-(test::assert-equal 5 (+ 5.0))
 (test::assert-equal 6 (+ 1 5))
 (test::assert-equal 6.5 (+ 1 5.5))
 (test::assert-equal 7 (+ 1 2 4))
@@ -750,6 +749,8 @@ Example:
 (test::assert-true (not= 1.1 1.0))
 (test::assert-false (not= 1.1 1.1))
 (test::assert-true (not= 3 2 3))
+(test::assert-true (not= 1 1.0))
+(test::assert-true (not= 1e-30 1.0001e-30))
 "#),
             numlt: add_special(vm, "<", r#"Usage: (< val0 ... valN)
 

--- a/doc/src/equality.md
+++ b/doc/src/equality.md
@@ -1,25 +1,16 @@
 # Equality
 
-When testing for equality in Slosh, there are several functions that can be used.
-Consider invocations like
-```slosh
-(= 1 2)
-```
-```slosh
-(== 1 2)
-```
-```slosh
-(identical? 1 2)
-```
-```slosh
-(assert-equal 1 2)
-```
-these are translated to different opcodes and equality implementations as listed below
+The most common way to test equality is with `=`
+For numeric equality (IEEE) use `==`
+For bytewise equality use `identical?`
 
--   `equal?`
+The behavior and names are based on Clojure's implementation. Read their docs here: https://clojure.org/guides/equality
 
-    -   lenient
-    -   `state.rs` defines special forms object with key `equal` mapped to the name `equal?`.
+-   `=`
+    -   `(= 2 0x2)` is `true` (comparing an int to a byte)
+    -   `(= 2 2.0)` is `false` (comparing an int to a float)
+    -   `(= NaN NaN)` is `false`
+    -   `state.rs` defines special forms object with key `equal` mapped to the name `=`.
     -   `compile.rs` matches on `env.specials().equal` and generates opcode `EQUAL`
     -   `exec_loop.rs` maps opcode `EQUAL` to function `is_equal`
     -   `vm.rs` `is_equal` converts each arg to a `Value` (in case it needs to be dereferenced) and calls `is_equal_pair`
@@ -27,29 +18,60 @@ these are translated to different opcodes and equality implementations as listed
         -   check if both args are Byte or Int and if so, converts both to `i64` with `Value::get_int` and compares with rust native `==`
         -   check if both args are Byte or Int or Float and if so, converts both to `f64` with `Value::get_float`
             -   then subtracts the second from the first and takes the absolute value and tests `diff == 0.0`
+-   `==`
+
+    -   `(== 1 1.0)` is `true` (comparing an int to a float)
+    -   `(== NaN NaN)` is `false`
+    -   returns true whenever `=` does, but also returns true for numbers that are numerically equal
+
+    -   when comparing two floats, converts two both to `f64` and compares with native f64 `==`
+    -   does not use F56::PartialEq implementation
+
+    -   `state.rs` defines special forms object with key `numeq` mapped to the name `==`.
+    -   `compile.rs` calls `compile_list` which calls `compile_special` which calls `compile_math` in `compile_math.rs`
+    -   `compile_math.rs` `compile_math` matches on `env.specials().numeq` and generates opcode `NUMEQ`
+    -   `exec_loop.rs` maps opcode `NUMEQ` to function `compare_numeric` and passes a comparator `|a,b| a == b`
+    -   `macros.rs` `compare_numeric`
+        -   checks if either argument is a `Float` and if so, converts both to `f64` with `get_primitive_float` macro and uses the comparator
+        -   checks if either argument is a `Int` and if so, converts both to `i64` with `get_primitive_int` macro and uses the comparator
+
+-   `identical?`
+
+    -   uses `Value::PartialEq` implementation
+    -   `state.rs` defines special forms object with key `eq` mapped to the name `identical?`.
+    -   `compile.rs` matches on `env.specials().eq` and generates opcode `EQ`
+    -   `exec_loop.rs` maps opcode `EQ` to function `is_identical`
+    -   `vm.rs` `is_identical` converts each arg to a `Value` (in case it needs to be dereferenced) and compares `val1 == val2` which uses `Value::PartialEq` implementation
 
 -   `assert-equal`
 
     -   based on `equal?`
     -   is a macro defined in core.slosh which checks if the arguments are `equal?` and throws an error if they are not
 
--   `eq?`
+-   `not=`
+    -   `(not= 1 2)` is equivalent to `(not (= 1 2))`
+    -   `(not= 1 1.0)` is `true` (comparing an int to a float)
+    -   `state.rs` defines special forms object with key `numneq` mapped to the name `not=`.
+    -   `compile_math.rs` converts `numneq` to opcode `NUMNEQ`
+    -   `exec_loop.rs` maps opcode `NUMNEQ` to a negation of the implementation of opcode `EQUAL` AKA `=`
 
-    -   uses `Value::PartialEq` implementation
-    -   `state.rs` defines special forms object with key `eq` mapped to the name `eq?`.
-    -   `compile.rs` matches on `env.specials().eq` and generates opcode `EQ`
-    -   `exec_loop.rs` maps opcode `EQ` to function `is_eq`
-    -   `vm.rs` `is_eq` converts each arg to a `Value` and compares `val1 == val2` which uses `Value::PartialEq` implementation
+### Moving Forward
 
--   `=`
-    -   numeric equality after converting to `i64` or `f64`
-    -   `state.rs` defines special forms object with key `numeq` mapped to the name `=`.
-    -   `compile.rs` calls `compile_list` which calls `compile_special` which calls `compile_math` in `compile_math.rs`
-    -   `compile_math.rs` `compile_math` matches on `env.specials().numeq` and generates opcode `NUMEQ`
-    -   `exec_loop.rs` maps opcode `NUMEQ` to function `compare_int` and passes two comparators
-        -   an integer comparator: `|a,b| a == b`
-        -   a float comparator: `|a: f64, b: f64| (a - b).abs() < f64::EPSILON`
-    -   `macros.rs` `compare_int`
-        -   checks if either argument is a `Float` and if so, converts both to `f64` with `get_float` macro and uses the float comparator
-        -   checks if either argument is a `Int` and if so, converts both to `i64` with `get_int` macro and uses the integer comparator
-    -   ultimately, ints are compared as i64 and floats are compared as f64 with a tolerance of `f64::EPSILON`
+-   = should be converted to =?
+-   =? should just be an alias for equal? which is the slower more intuitive equality check
+-   eq? is the faster more strict equality check but it does spend a little extra time making sure to dereference captured heap values
+-   eq? on floats should do an IEEE comparison
+-   eq? should consider 1.0 equal to 1
+-   equal? on floats should do a fuzzy comparison
+-   if we want a bitwise comparison of floats we will implement it later
+
+eq? does not do type coercion
+just do what clojure does
+numeq should be a bit fuzzy
+NaN != NaN is false and NaN == NaN is false
+
+may 1 2024
+= (equal) loosy goosey (still use IEEE comparison)
+== (=?) (for numbers) (IEEE comparison)
+identical? (eq?) (bytewise equality)
+users who want rough epsilon equality can defn their own fn

--- a/slosh/tests/equality.slosh
+++ b/slosh/tests/equality.slosh
@@ -1,0 +1,8 @@
+#!/usr/bin/env slosh
+
+(assert-true (= 1 1))
+(assert-false (= 2 2.0))
+(assert-true (not= 2 2.0))
+(assert-true (== 2 2.0))
+(assert-true (== 2 2.000000000000000000000000000000000000000000001))
+(assert-false(== 1e-30 1.001e-30))

--- a/slosh/tests/equality.slosh
+++ b/slosh/tests/equality.slosh
@@ -6,3 +6,10 @@
 (assert-true (== 2 2.0))
 (assert-true (== 2 2.000000000000000000000000000000000000000000001))
 (assert-false(== 1e-30 1.001e-30))
+
+(assert-true(          = 0   -0))
+(assert-true(         == 0   -0))
+(assert-true( identical? 0   -0))
+(assert-true(          = 0.0 -0.0))
+(assert-true(         == 0.0 -0.0))
+(assert-false(identical? 0.0 -0.0))

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -245,6 +245,18 @@ impl Value {
         matches!(&self, Value::Byte(_) | Value::Int(_) | Value::Float(_))
     }
 
+    pub fn is_float(&self) -> bool {
+        matches!(self, Value::Float(_))
+    }
+
+    pub fn not(&self) -> Value {
+        match self {
+            Value::False => Value::True,
+            Value::Nil => Value::True,
+            _ => Value::False,
+        }
+    }
+
     pub fn get_int<ENV>(&self, _vm: &GVm<ENV>) -> VMResult<i64> {
         match &self {
             Value::Byte(b) => Ok(*b as i64),

--- a/vm/src/vm/exec_loop.rs
+++ b/vm/src/vm/exec_loop.rs
@@ -805,7 +805,9 @@ impl<ENV> GVm<ENV> {
                 }
                 EQ => {
                     let (dest, reg1, reg2) = decode3!(self.ip_ptr, wide);
-                    let val = self.is_eq(reg1, reg2).map_err(|e| (e, chunk.clone()))?;
+                    let val = self
+                        .is_identical(reg1, reg2)
+                        .map_err(|e| (e, chunk.clone()))?;
                     set_register!(self, dest as usize, val);
                 }
                 EQUAL => {
@@ -948,30 +950,29 @@ impl<ENV> GVm<ENV> {
                 SUB => binary_math!(self, chunk, self.ip_ptr, |a, b| a - b, wide),
                 MUL => binary_math!(self, chunk, self.ip_ptr, |a, b| a * b, wide),
                 DIV => div_math!(self, chunk, self.ip_ptr, wide),
-                NUMEQ => compare_int!(
-                    self,
-                    chunk,
-                    self.ip_ptr,
-                    |a, b| a == b,
-                    |a: f64, b: f64| (a - b).abs() < f64::EPSILON,
-                    wide,
-                    true,
-                    false
-                ),
-                NUMNEQ => compare_int!(
-                    self,
-                    chunk,
-                    self.ip_ptr,
-                    |a, b| a == b,
-                    |a: f64, b: f64| (a - b).abs() < f64::EPSILON,
-                    wide,
-                    true,
-                    true
-                ),
-                NUMLT => compare!(self, chunk, self.ip_ptr, |a, b| a < b, wide, true),
-                NUMLTE => compare!(self, chunk, self.ip_ptr, |a, b| a <= b, wide, true),
-                NUMGT => compare!(self, chunk, self.ip_ptr, |a, b| a > b, wide, true),
-                NUMGTE => compare!(self, chunk, self.ip_ptr, |a, b| a >= b, wide, true),
+                NUMEQ => {
+                    compare_numeric!(self, chunk, self.ip_ptr, |a, b| a == b, wide)
+                }
+                NUMNEQ => {
+                    // TODO: #142 NUMNEQ is being hijacked temporarily to implement clojure `not=` which is a non-numeric comparison
+                    let (dest, reg1, reg2) = decode3!(self.ip_ptr, wide);
+                    let val = self.is_equal(reg1, reg2).map_err(|e| (e, chunk.clone()))?;
+                    set_register!(self, dest as usize, val.not());
+                    // This is what NUMNEQ would look like if it were a numeric comparison
+                    // compare_numeric!(self, chunk, self.ip_ptr, |a, b| a != b, wide)
+                }
+                NUMLT => {
+                    compare_numeric!(self, chunk, self.ip_ptr, |a, b| a < b, wide)
+                }
+                NUMLTE => {
+                    compare_numeric!(self, chunk, self.ip_ptr, |a, b| a <= b, wide)
+                }
+                NUMGT => {
+                    compare_numeric!(self, chunk, self.ip_ptr, |a, b| a > b, wide)
+                }
+                NUMGTE => {
+                    compare_numeric!(self, chunk, self.ip_ptr, |a, b| a >= b, wide)
+                }
                 INC => {
                     let (dest, i) = decode2!(self.ip_ptr, wide);
                     match self.register(dest as usize) {

--- a/vm/src/vm/exec_loop.rs
+++ b/vm/src/vm/exec_loop.rs
@@ -954,7 +954,7 @@ impl<ENV> GVm<ENV> {
                     compare_numeric!(self, chunk, self.ip_ptr, |a, b| a == b, wide)
                 }
                 NUMNEQ => {
-                    // TODO: #142 NUMNEQ is being hijacked temporarily to implement clojure `not=` which is a non-numeric comparison
+                    // TODO: #171 NUMNEQ is being hijacked temporarily to implement clojure `not=` which is a non-numeric comparison
                     let (dest, reg1, reg2) = decode3!(self.ip_ptr, wide);
                     let val = self.is_equal(reg1, reg2).map_err(|e| (e, chunk.clone()))?;
                     set_register!(self, dest as usize, val.not());


### PR DESCRIPTION
Further information about this change is available in `doc/src/equality.md` file which explains the difference between the three core equality operations `=`, `==`, and `identical?`. They're also meant to map directly onto the same operations in Clojure. 



Original commits were squashed into 1, but their messages remain below
---
rename get_int macro to get_primitive_int
rename compare_int to compare_numeric
refactor NUM_LT, NUM_LTE, NUM_GT, NUM_GTE to use compare_numeric and removed helper macro
updated equality docs
implemented clojure-style = and == and not=
implemented identical