### PR TITLE
Fix issues exposed by fs-crawl tests (map, inc!/dec! bugs).

### DIFF
--- a/bridge_adapters/src/lisp_adapters/collections.rs
+++ b/bridge_adapters/src/lisp_adapters/collections.rs
@@ -1,10 +1,10 @@
 use crate::lisp_adapters::{SlFromRef, SlFromRefMut};
 use bridge_types::ErrorStrings;
 use compile_state::state::SloshVm;
+use slvm::vm_hashmap::VMHashMap;
 use slvm::{VMError, VMResult, Value, ValueType};
-use std::collections::HashMap;
 
-impl<'a> SlFromRef<'a, Value> for &'a HashMap<Value, Value> {
+impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
         match value {
             Value::Map(h) => Ok(vm.get_map(h)),
@@ -18,7 +18,7 @@ impl<'a> SlFromRef<'a, Value> for &'a HashMap<Value, Value> {
     }
 }
 
-impl<'a> SlFromRefMut<'a, Value> for &'a mut HashMap<Value, Value> {
+impl<'a> SlFromRefMut<'a, Value> for &'a mut VMHashMap {
     fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> VMResult<Self> {
         match value {
             Value::Map(h) => Ok(vm.get_map_mut(h)?),

--- a/bridge_types/src/lib.rs
+++ b/bridge_types/src/lib.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt::Display;
 
 /// Marker traits
@@ -12,14 +11,6 @@ impl<T> BridgedType for Option<T> where T: BridgedType {}
 
 /// A [`Result`] value that contains a [`BridgedType`] can be represented as a rust value.
 impl<T, U> BridgedType for Result<T, U> where T: BridgedType {}
-
-/// A [`HashMap`] that contains a [`BridgedType`] can be represented as a rust value.
-impl<T, U> BridgedType for HashMap<T, U>
-where
-    T: BridgedType,
-    U: BridgedType,
-{
-}
 
 /// A [`Vec`] that contains a [`BridgedType`] can be represented as a rust value.
 impl<T> BridgedType for Vec<T> where T: BridgedType {}

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -279,9 +279,9 @@ Section: random
 
 Example:
 (def rand-int (random 100))
-(test::assert-true (and (> rand-int 0) (< rand-int 100)))
+(test::assert-true (and (>= rand-int 0) (< rand-int 100)))
 (def rand-float (random 1.0))
-(test::assert-true (and (> rand-float 0) (< rand-float 1)))
+(test::assert-true (and (>= rand-float 0.0) (< rand-float 1.0)))
 (test::assert-error-msg (random -1) :rand \"Expected positive number\")
 (test::assert-error-msg (random 1 2) :rand \"Expected positive number, float or int\")
 ",

--- a/vm/src/heap/vm_hashmap.rs
+++ b/vm/src/heap/vm_hashmap.rs
@@ -1,0 +1,281 @@
+use crate::{GVm, Value};
+use bridge_types::BridgedType;
+use std::collections::hash_map::Keys;
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash, Hasher};
+
+/**
+ * Provides a wrapper to allow us to build a hashmap with Value keys that hashes String and StringConst
+ * to the same hash.
+ * Note, this is public only to allow use of insert_id and remove_id which we need to work around
+ * borrowing issues.
+*/
+#[derive(Copy, Clone, Debug)]
+pub struct ValHash {
+    val: Value,
+    hash: u64,
+}
+
+impl ValHash {
+    /** Make a ValHash from a Value. */
+    pub fn from_value<ENV>(vm: &GVm<ENV>, val: Value) -> Self {
+        ValHash {
+            val,
+            hash: val.get_hash(vm),
+        }
+    }
+}
+
+impl PartialEq for ValHash {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+    }
+}
+
+impl Eq for ValHash {}
+
+impl Hash for ValHash {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+struct IdHasher {
+    hash: u64,
+}
+
+impl BuildHasher for IdHasher {
+    type Hasher = IdHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        *self
+    }
+}
+
+impl Hasher for IdHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        panic!("Invalid use of IdHasher!");
+    }
+
+    fn write_u64(&mut self, val: u64) {
+        self.hash = val;
+    }
+}
+
+/**
+ * Wrapper class for a HashMap<Value, Value>.  We need this because we want String and StringConst
+ * to hash to the same value (what a script user will expect) and that requires a VM so can not just
+ * implement Hash on Value (will not have access to a VM).
+ */
+#[derive(Clone, Debug)]
+pub struct VMHashMap {
+    map: HashMap<ValHash, Value, IdHasher>,
+}
+
+impl VMHashMap {
+    /** Create a new empty HashMap. */
+    pub fn new() -> Self {
+        VMHashMap {
+            map: HashMap::default(),
+        }
+    }
+
+    /** Create a new empty HashMap with an initial capacity. */
+    pub fn with_capacity(cap: usize) -> Self {
+        VMHashMap {
+            map: HashMap::with_capacity_and_hasher(cap, IdHasher::default()),
+        }
+    }
+
+    /** Get the value at key, requires the current VM for hashing. */
+    pub fn get<ENV>(&self, vm: &GVm<ENV>, key: Value) -> Option<Value> {
+        let id = ValHash::from_value(vm, key);
+        self.map.get(&id).copied()
+    }
+
+    /** Insert the value at key, requires the current VM for hashing.
+     * Returns the old value at key if it exists (None otherwise).
+     */
+    pub fn insert<ENV>(&mut self, vm: &GVm<ENV>, key: Value, val: Value) -> Option<Value> {
+        let id = ValHash::from_value(vm, key);
+        self.map.insert(id, val)
+    }
+
+    /** Insert val at the key id provided.  This allows calling code to pre-generate the ValHash.
+     * This is a borrow checker workaround.
+     */
+    pub fn insert_id(&mut self, id: ValHash, val: Value) -> Option<Value> {
+        self.map.insert(id, val)
+    }
+
+    /** Number of items in the HashMap. */
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /** Is this HashMap empty? */
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /** Does this HashMap contain key? */
+    pub fn contains_key<ENV>(&self, vm: &GVm<ENV>, key: Value) -> bool {
+        let id = ValHash::from_value(vm, key);
+        self.map.contains_key(&id)
+    }
+
+    /** Clear (remove all key/values) from the HashMap. */
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    /** Remove key from the HashMap.  Return the old value if it existed (None otherwise). */
+    pub fn remove<ENV>(&mut self, vm: &GVm<ENV>, key: Value) -> Option<Value> {
+        let id = ValHash::from_value(vm, key);
+        self.map.remove(&id)
+    }
+
+    /** Remove the key from HashMap (like remove) except caller pre-generates the ValHash.  Used to
+     * work around the borrow checker. */
+    pub fn remove_id(&mut self, id: ValHash) -> Option<Value> {
+        self.map.remove(&id)
+    }
+
+    /** Returns an iterator over all the keys in the HashMap. */
+    pub fn keys(&self) -> VMMapKeys {
+        VMMapKeys {
+            keys: self.map.keys(),
+        }
+    }
+
+    /** Return an iterator over all the (key, value) pairs in the HashMap. */
+    pub fn iter(&self) -> VMHashMapIter {
+        VMHashMapIter {
+            iter: self.map.iter(),
+        }
+    }
+}
+
+/// A [`VMHashMap`] that contains a [`BridgedType`] can be represented as a rust value.
+impl BridgedType for VMHashMap {}
+
+impl Default for VMHashMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/** Iterator over the key vals in a HashMap. */
+pub struct VMHashMapIter<'a> {
+    iter: std::collections::hash_map::Iter<'a, ValHash, Value>,
+}
+
+impl<'a> Iterator for VMHashMapIter<'a> {
+    type Item = (Value, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(k, v)| (k.val, *v))
+    }
+}
+
+/** Iterator over the keys in a HashMap. */
+pub struct VMMapKeys<'a> {
+    keys: Keys<'a, ValHash, Value>,
+}
+
+impl<'a> Iterator for VMMapKeys<'a> {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.keys.next().map(|v| v.val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vm_hashmap::VMHashMap;
+    use crate::{Value, Vm};
+
+    #[test]
+    fn test_map_str() {
+        let mut vm = Vm::new();
+        let mut m = VMHashMap::default();
+        let cs = Value::StringConst(vm.intern("Test String"));
+        let ds = vm.alloc_string("Test String".to_string());
+        let i: Value = 1.into();
+        m.insert(&mut vm, cs, i);
+        assert_eq!(m.get(&vm, cs).unwrap(), i);
+        assert_eq!(m.get(&vm, ds).unwrap(), i);
+        let i: Value = 10.into();
+        m.insert(&mut vm, ds, i);
+        assert_eq!(m.get(&vm, cs).unwrap(), i);
+        assert_eq!(m.get(&vm, ds).unwrap(), i);
+        let old = m.remove(&mut vm, cs).unwrap();
+        assert_eq!(old, i);
+        assert!(m.get(&vm, cs).is_none());
+        assert!(m.get(&vm, ds).is_none());
+    }
+
+    #[test]
+    fn test_map_sym_key_sanity() {
+        let mut vm = Vm::new();
+        let mut m = VMHashMap::default();
+        let sym = Value::Symbol(vm.intern("Test String"));
+        let key = Value::Keyword(vm.intern("Test String"));
+        let i: Value = 1.into();
+        m.insert(&mut vm, sym, i);
+        assert_eq!(m.get(&vm, sym).unwrap(), i);
+        assert!(m.get(&vm, key).is_none());
+        let i2: Value = 10.into();
+        m.insert(&mut vm, key, i2);
+        assert_eq!(m.get(&vm, sym).unwrap(), i);
+        assert_eq!(m.get(&vm, key).unwrap(), i2);
+        let old = m.remove(&mut vm, sym).unwrap();
+        assert_eq!(old, i);
+        assert!(m.get(&vm, sym).is_none());
+        assert_eq!(m.get(&vm, key).unwrap(), i2);
+    }
+
+    #[test]
+    fn test_map_key_iter_sanity() {
+        let mut vm = Vm::new();
+        let mut m = VMHashMap::default();
+        let key1 = Value::Keyword(vm.intern("one"));
+        let key2 = Value::Keyword(vm.intern("two"));
+        let key3 = Value::Keyword(vm.intern("three"));
+        assert_eq!(m.keys().count(), 0);
+        let i1: Value = 1.into();
+        m.insert(&mut vm, key1, i1);
+        let i2: Value = 1.into();
+        m.insert(&mut vm, key2, i2);
+        let i3: Value = 1.into();
+        m.insert(&mut vm, key3, i3);
+        assert_eq!(m.keys().count(), 3);
+        m.remove(&mut vm, key1);
+        assert_eq!(m.keys().count(), 2);
+    }
+
+    #[test]
+    fn test_map_iter_sanity() {
+        let mut vm = Vm::new();
+        let mut m = VMHashMap::default();
+        let key1 = Value::Keyword(vm.intern("one"));
+        let key2 = Value::Keyword(vm.intern("two"));
+        let key3 = Value::Keyword(vm.intern("three"));
+        assert_eq!(m.iter().count(), 0);
+        let i1: Value = 1.into();
+        m.insert(&mut vm, key1, i1);
+        let i2: Value = 1.into();
+        m.insert(&mut vm, key2, i2);
+        let i3: Value = 1.into();
+        m.insert(&mut vm, key3, i3);
+        assert_eq!(m.iter().count(), 3);
+        m.remove(&mut vm, key1);
+        assert_eq!(m.iter().count(), 2);
+    }
+}

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -345,8 +345,8 @@ impl<ENV> GVm<ENV> {
                             // must set val to false in two instances because
                             // its possible a previous iteration set val to true.
                             for (k, v) in m1.iter() {
-                                if let Some(v2) = m2.get(k) {
-                                    if self.is_equal_pair(*v, *v2)? == Value::False {
+                                if let Some(v2) = m2.get(self, k) {
+                                    if self.is_equal_pair(v, v2)? == Value::False {
                                         val = Value::False;
                                         break;
                                     } else {

--- a/vm/src/vm/call_collection.rs
+++ b/vm/src/vm/call_collection.rs
@@ -10,8 +10,8 @@ impl<ENV> GVm<ENV> {
         match num_args {
             1 => {
                 let map = self.heap().get_map(handle);
-                let res = if let Some(val) = map.get(&self.register(first_reg as usize + 1)) {
-                    *val
+                let res = if let Some(val) = map.get(self, self.register(first_reg as usize + 1)) {
+                    val
                 } else {
                     Value::Nil
                 };
@@ -19,8 +19,8 @@ impl<ENV> GVm<ENV> {
             }
             2 => {
                 let map = self.heap().get_map(handle);
-                let res = if let Some(val) = map.get(&self.register(first_reg as usize + 1)) {
-                    *val
+                let res = if let Some(val) = map.get(self, self.register(first_reg as usize + 1)) {
+                    val
                 } else {
                     self.register(first_reg as usize + 2)
                 };

--- a/vm/src/vm/exec_loop.rs
+++ b/vm/src/vm/exec_loop.rs
@@ -1,10 +1,11 @@
 use crate::opcodes::*;
+use crate::vm_hashmap::{VMHashMap, ValHash};
 use crate::{
     from_i56, CallFrame, Chunk, Continuation, Error, GVm, VMError, VMErrorObj, VMResult, Value,
     STACK_CAP,
 };
-use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::num::TryFromIntError;
 use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -26,8 +27,8 @@ impl<ENV> GVm<ENV> {
                     let map = self.get_map(handle);
                     for i in 0..len {
                         let key = self.register(dest + i);
-                        if let Some(item) = map.get(&key) {
-                            *self.register_mut(dest + i) = *item;
+                        if let Some(item) = map.get(self, key) {
+                            *self.register_mut(dest + i) = item;
                         } else {
                             *self.register_mut(dest + i) = Value::Undefined;
                         }
@@ -220,8 +221,8 @@ impl<ENV> GVm<ENV> {
             Value::Map(h) => {
                 let map = self.get_map(h);
                 let key = self.register(i as usize);
-                if let Some(val) = map.get(&key) {
-                    *val
+                if let Some(val) = map.get(self, key) {
+                    val
                 } else {
                     self.make_err("vm-missing", key)
                 }
@@ -314,9 +315,9 @@ impl<ENV> GVm<ENV> {
             }
             Value::Map(h) => {
                 let key = self.register(i as usize);
+                let id = ValHash::from_value(self, key);
                 let map = self.get_map_mut(h)?;
-                let slot = map.entry(key);
-                *slot.or_insert(Value::Undefined) = src;
+                map.insert_id(id, src);
             }
             _ => {
                 return Err(VMError::new_vm(format!(
@@ -333,6 +334,96 @@ impl<ENV> GVm<ENV> {
     /// munge the return.
     fn tail_builtin_exit(&self, lambda: Value) -> bool {
         matches!(lambda, Value::Builtin(_)) && self.call_frame().is_none()
+    }
+
+    /** Implementation of the INC bytecode. */
+    fn inc_val(&mut self, wide: bool) -> VMResult<()> {
+        let (dest, i) = decode2!(self.ip_ptr, wide);
+        match self.register(dest as usize) {
+            Value::Byte(v) => {
+                let i: u8 = i
+                    .try_into()
+                    .map_err(|e: TryFromIntError| VMError::new_vm(e.to_string()))?;
+                *self.register_mut(dest as usize) = Value::Byte(v + i);
+                Ok(())
+            }
+            Value::Int(v) => {
+                let v = from_i56(&v);
+                *self.register_mut(dest as usize) = (v + i as i64).into();
+                Ok(())
+            }
+            // Handle closed over values...
+            Value::Value(h) => {
+                let val = self.get_value_mut(h);
+                match val {
+                    Value::Byte(v) => {
+                        let i: u8 = i
+                            .try_into()
+                            .map_err(|e: TryFromIntError| VMError::new_vm(e.to_string()))?;
+                        *val = Value::Byte(*v + i);
+                        Ok(())
+                    }
+                    Value::Int(v) => {
+                        let v = from_i56(v);
+                        *val = (v + i as i64).into();
+                        Ok(())
+                    }
+                    _ => Err(VMError::new_vm(format!(
+                        "INC: Can only INC an integer type, got {:?}.",
+                        val
+                    ))),
+                }
+            }
+            _ => Err(VMError::new_vm(format!(
+                "INC: Can only INC an integer type, got {:?}.",
+                self.register(dest as usize)
+            ))),
+        }
+    }
+
+    /** Implementation of the DEC bytecode. */
+    fn dec_val(&mut self, wide: bool) -> VMResult<()> {
+        let (dest, i) = decode2!(self.ip_ptr, wide);
+        match self.register(dest as usize) {
+            Value::Byte(v) => {
+                let i: u8 = i
+                    .try_into()
+                    .map_err(|e: TryFromIntError| VMError::new_vm(e.to_string()))?;
+                *self.register_mut(dest as usize) = Value::Byte(v - i);
+                Ok(())
+            }
+            Value::Int(v) => {
+                let v = from_i56(&v);
+                *self.register_mut(dest as usize) = (v - i as i64).into();
+                Ok(())
+            }
+            // Handle closed over values...
+            Value::Value(h) => {
+                let val = self.get_value_mut(h);
+                match val {
+                    Value::Byte(v) => {
+                        let i: u8 = i
+                            .try_into()
+                            .map_err(|e: TryFromIntError| VMError::new_vm(e.to_string()))?;
+                        *val = Value::Byte(*v - i);
+                        Ok(())
+                    }
+                    Value::Int(v) => {
+                        let v = from_i56(v);
+                        *val = (v - i as i64).into();
+                        Ok(())
+                    }
+                    _ => Err(VMError::new_vm(format!(
+                        "INC: Can only INC an integer type, got {:?}.",
+                        val
+                    ))),
+                }
+            }
+            _ => Err(VMError::new_vm(format!(
+                "DEC: Can only DEC an integer type, got {:?}.",
+                self.register(dest as usize)
+            ))),
+        }
     }
 
     // Some macro expansions trips this.
@@ -972,48 +1063,8 @@ impl<ENV> GVm<ENV> {
                 NUMLTE => compare!(self, chunk, self.ip_ptr, |a, b| a <= b, wide, true),
                 NUMGT => compare!(self, chunk, self.ip_ptr, |a, b| a > b, wide, true),
                 NUMGTE => compare!(self, chunk, self.ip_ptr, |a, b| a >= b, wide, true),
-                INC => {
-                    let (dest, i) = decode2!(self.ip_ptr, wide);
-                    match self.register(dest as usize) {
-                        Value::Byte(v) => {
-                            *self.register_mut(dest as usize) = Value::Byte(v + i as u8)
-                        }
-                        Value::Int(v) => {
-                            let v = from_i56(&v);
-                            *self.register_mut(dest as usize) = (v + i as i64).into()
-                        }
-                        _ => {
-                            return Err((
-                                VMError::new_vm(format!(
-                                    "INC: Can only INC an integer type, got {:?}.",
-                                    self.register(dest as usize)
-                                )),
-                                chunk,
-                            ))
-                        }
-                    }
-                }
-                DEC => {
-                    let (dest, i) = decode2!(self.ip_ptr, wide);
-                    match self.register(dest as usize) {
-                        Value::Byte(v) => {
-                            *self.register_mut(dest as usize) = Value::Byte(v - i as u8)
-                        }
-                        Value::Int(v) => {
-                            let v = from_i56(&v);
-                            *self.register_mut(dest as usize) = (v - i as i64).into()
-                        }
-                        _ => {
-                            return Err((
-                                VMError::new_vm(format!(
-                                    "DEC: Can only DEC an integer type, got {:?}.",
-                                    self.register(dest as usize)
-                                )),
-                                chunk,
-                            ))
-                        }
-                    }
-                }
+                INC => self.inc_val(wide).map_err(|e| (e, chunk.clone()))?,
+                DEC => self.dec_val(wide).map_err(|e| (e, chunk.clone()))?,
                 CONS => {
                     let (dest, op2, op3) = decode3!(self.ip_ptr, wide);
                     let car = self.register(op2 as usize);
@@ -1084,7 +1135,7 @@ impl<ENV> GVm<ENV> {
                 MAPMK => {
                     let (dest, start, end) = decode3!(self.ip_ptr, wide);
                     let map = if end == start {
-                        HashMap::new()
+                        VMHashMap::new()
                     } else if (end - start) % 2 != 0 {
                         return Err((
                             VMError::new_vm(
@@ -1094,9 +1145,13 @@ impl<ENV> GVm<ENV> {
                             chunk.clone(),
                         ));
                     } else {
-                        let mut map = HashMap::new();
+                        let mut map = VMHashMap::new();
                         for i in (start..end).step_by(2) {
-                            map.insert(self.register(i as usize), self.register(i as usize + 1));
+                            map.insert(
+                                self,
+                                self.register(i as usize),
+                                self.register(i as usize + 1),
+                            );
                         }
                         map
                     };

--- a/vm/src/vm/storage.rs
+++ b/vm/src/vm/storage.rs
@@ -1,9 +1,9 @@
 use crate::heap::Error;
 use crate::{CallFrame, Chunk, Continuation, Handle, Heap, Interned, MutState, VMResult, Value};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::io::HeapIo;
+use crate::vm_hashmap::VMHashMap;
 use crate::GVm;
 
 /// Vm code to access storage, heap, stack, globals, etc.
@@ -157,14 +157,14 @@ impl<ENV> GVm<ENV> {
         res
     }
 
-    pub fn alloc_map(&mut self, map: HashMap<Value, Value>) -> Value {
+    pub fn alloc_map(&mut self, map: VMHashMap) -> Value {
         let mut heap = self.heap.take().expect("VM must have a Heap!");
         let res = heap.alloc_map(map, MutState::Mutable, |heap| self.mark_roots(heap));
         self.heap = Some(heap);
         res
     }
 
-    pub fn alloc_map_ro(&mut self, map: HashMap<Value, Value>) -> Value {
+    pub fn alloc_map_ro(&mut self, map: VMHashMap) -> Value {
         let mut heap = self.heap.take().expect("VM must have a Heap!");
         let res = heap.alloc_map(map, MutState::Immutable, |heap| self.mark_roots(heap));
         self.heap = Some(heap);
@@ -322,11 +322,11 @@ impl<ENV> GVm<ENV> {
         self.heap_mut().get_vector_mut(handle)
     }
 
-    pub fn get_map(&self, handle: Handle) -> &HashMap<Value, Value> {
+    pub fn get_map(&self, handle: Handle) -> &VMHashMap {
         self.heap().get_map(handle)
     }
 
-    pub fn get_map_mut(&mut self, handle: Handle) -> VMResult<&mut HashMap<Value, Value>> {
+    pub fn get_map_mut(&mut self, handle: Handle) -> VMResult<&mut VMHashMap> {
         self.heap_mut().get_map_mut(handle)
     }
 


### PR DESCRIPTION
This is a bugfix PR, the fs-crawl tests exposed a couple of issue not related to fs-crawl...

- When using maps in lisp String and StringConst will hash to the same value for the same string.
- Fixed an issue with inc!/dec! on closed over values (they did not work).
- Tweaked the random tests so they should not fail about 1% of the time (see recent main CI failure).