### PR TITLE
Satisfy clippy 0.1.78

### DIFF
--- a/bridge_macros/src/lib.rs
+++ b/bridge_macros/src/lib.rs
@@ -1488,7 +1488,7 @@ fn get_documentation_for_fn(original_item_fn: &ItemFn) -> MacroResult<String> {
             if &path_segment.ident.to_string() == "doc" {
                 if let Ok(Meta::NameValue(pair)) = attr.parse_meta() {
                     if let Lit::Str(partial_name) = &pair.lit {
-                        docs += &(*partial_name.value()).trim();
+                        docs += (*partial_name.value()).trim();
                         docs += "\n";
                     }
                 }

--- a/builtins/trybuild/tests/too_many_generics_fail.rs
+++ b/builtins/trybuild/tests/too_many_generics_fail.rs
@@ -5,5 +5,6 @@ pub fn main() {}
 /// obligatory doc
 #[sl_sh_fn(fn_name = "too_many_generics")]
 pub fn too_many_generics<'a, 'b>(a: &'a str, b: &'b str) -> &'a str {
+    println!("{}", b); // prevent warning about unused variable
     a
 }

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -69,6 +69,7 @@ impl Symbols {
         self.data.borrow().syms.contains_key(&key)
     }
 
+    #[allow(clippy::assigning_clones)] // clippy warns about clone on copy for performance, but we need to do it this way to avoid a borrow checker error.
     pub fn can_capture(&self, key: Interned) -> bool {
         let mut loop_outer = self.outer.clone();
         while let Some(outer) = loop_outer {

--- a/slosh_test/src/docs.rs
+++ b/slosh_test/src/docs.rs
@@ -606,7 +606,7 @@ fn build_each_docs_section_chapter(
         }
 
         let header = "\n\nList of symbols: \n\n".to_string();
-        content = content + &header + &list;
+        content = content + &header + list;
 
         let path = make_file(section, &content)
             .map_err(|e| VMError::new_vm(format!("Failed to write to file: {e}.")))?;


### PR DESCRIPTION
Github CI runners are now using Cargo 1.78.0 which includes clippy 0.1.78 which added some new warnings which I resolve in this commit.

1. In `bridge_macros/src/lib.rs` and
2. In `slosh_test/src/docs.rs`, there were some `needless_borrow`s with the warning: this expression creates a reference which is immediately dereferenced by the compiler

3. in `builtins/trybuild/tests/too_many_generics_fail.rs` we expect an exact error message about generics. After the update it was also warning that variable `b` was unused, so I added a call to println! `b` so it is no longer unused and the error message now looks just as expected.

4. in `compile_state/src/state.rs` a new warning about assigning clones should be ignored.
> The `clone_from` method in Rust replaces the current value in-place with the value from another object, which is more efficient than using clone in some cases. However, in this case, we can't use `clone_from` because `loop_outer` is being used in the while let statement.
>
> The while let statement is trying to destructure `loop_outer`, which means it needs to take ownership of `loop_outer`. If we were to use `clone_from`, `loop_outer` would still be borrowed at the time of the while let statement, which would cause a borrow checker error.
>
> The Clippy lint that suggests using `clone_from` is a performance lint, so it's okay to ignore it in this situation.