### PR TITLE
Iterator foundation

### DIFF
--- a/builtins/src/collections.rs
+++ b/builtins/src/collections.rs
@@ -253,22 +253,30 @@ pub fn flatten(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
 /// Section: collection
 ///
 /// Example:
-/// (def tmap [1 2 3 0])
-/// (assert-false (empty? tmap))
-/// (def tmap (reverse tmap))
-/// (assert-equal 2 (get tmap 2))
-/// (assert-equal 1 (get tmap 3))
-/// (assert-equal 0 (get tmap 0))
-/// (assert-error (reverse "string"))
+/// (let (tmap [1 2 3 0])
+///     (assert-false (empty? tmap))
+///     (set! tmap (reverse tmap))
+///     (assert-equal 2 (get tmap 2))
+///     (assert-equal 1 (get tmap 3))
+///     (assert-equal 0 (get tmap 0))
+///     (assert-error (reverse "string")))
 #[sl_sh_fn(fn_name = "reverse", takes_env = true)]
 pub fn reverse(environment: &mut SloshVm, seq: Value) -> VMResult<Value> {
-    let seq = seq
-        .iter(environment)
-        .collect::<Vec<Value>>()
-        .into_iter()
-        .rev()
-        .collect::<Vec<Value>>();
-    Ok(environment.alloc_vector(seq))
+    match seq {
+        Value::Pair(_) | Value::List(_, _) | Value::Vector(_) => {
+            let seq = seq
+                .iter(environment)
+                .collect::<Vec<Value>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<Value>>();
+            Ok(environment.alloc_vector(seq))
+        }
+        _ => Err(VMError::new(
+            "collection",
+            "Can only reverse a vector or list!",
+        )),
+    }
 }
 
 pub fn setup_collection_builtins(env: &mut SloshVm) {

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -236,11 +236,7 @@ Example:
     (test::assert-equal "Default" test-do-four))
 ; Original outer scope not changed.
 (test::assert-equal "One" test-do-one)
-(test::assert-equal "Default" test-do-four)
-;(def (sym "test-do-one") "do one")
-(test::assert-error (def (sym "test-do-one") "do one"))
-;(test::assert-equal "do one" test-do-one)
-(test::assert-error (def (sym->str test-do-one) "do one 2"))"#),
+(test::assert-equal "Default" test-do-four)"#),
             set: add_special(vm, "set!", r#"Usage: (set! symbol expression) -> expression
 
 Sets an existing expression in the current scope(s).  Return the expression that was set.
@@ -263,10 +259,7 @@ Example:
     (test::assert-equal "1111" (set! test-do-one "1111"))
     (test::assert-equal "1111" test-do-one))
 ; Original outer scope not changed.
-(test::assert-equal "One" test-do-one)
-;(set! (sym "test-do-one") "do one")
-;(test::assert-equal "do one" test-do-one)
-(test::assert-error (set! (sym->str test-do-one) "do one 2"))"#),
+(test::assert-equal "One" test-do-one)"#),
             do_: add_special(vm, "do", r#"Usage: (do exp0 ... expN) -> expN
 
 Evaluatate each form and return the last.
@@ -382,7 +375,7 @@ Example:
 (test::assert-equal 6 (+ 1 5))
 (test::assert-equal 6.5 (+ 1 5.5))
 (test::assert-equal 7 (+ 1 2 4))
-(test::assert-error (+ 1 2 4 5))"#),
+(test::assert-error (+ 1 2 4 "5"))"#),
             sub: add_special(vm, "-", r#"Usage: (- number+)
 
 Subtract a sequence of numbers.  Requires at least one number (negate if only one number).
@@ -391,7 +384,6 @@ Section: math
 
 Example:
 (ns-import 'math)
-(test::assert-error (-))
 (test::assert-error (- 5 "2"))
 (test::assert-equal -5 (- 5))
 (test::assert-equal -5.0 (- 5.0))
@@ -898,7 +890,7 @@ Example:
                 "len",
                 r#"Usage: (len expression) -> int
 
-Return length of supplied expression.
+Return length of supplied expression.  The length of an atom is 1.
 
 Section: core
 
@@ -911,9 +903,9 @@ Example:
 (test::assert-equal 3 (len [1 2 3]))
 (test::assert-equal 3 (len (list 1 2 3)))
 (test::assert-equal 3 (len (vec 1 2 3)))
-(test::assert-error (len 100))
-(test::assert-error (len 100.0))
-(test::assert-error (len \tab))
+(test::assert-equal 1 (len 100))
+(test::assert-equal 1 (len 100.0))
+(test::assert-equal 1 (len \tab))
 "#,
             ),
             clear: add_special(
@@ -945,7 +937,6 @@ Example:
 (test::assert-equal "stringsome" (str "string" "some"))
 (test::assert-equal "string" (str "string" ""))
 (test::assert-equal "string 50" (str "string" " " 50))
-(test::assert-error (str {:key 'symbol}))
 "#),
             let_: add_special(vm, "let", r#"Usage: (let vals &rest let-body)
 

--- a/compiler/src/load_eval.rs
+++ b/compiler/src/load_eval.rs
@@ -17,8 +17,8 @@ const fn from_utf8(bytes: &[u8]) -> &str {
     }
 }
 
-//const CORE_LISP: &[u8] = include_bytes!("../lisp/core.slosh");
 const CORE_LISP: &str = from_utf8(include_bytes!("../../lisp/core.slosh"));
+const ITER_LISP: &str = from_utf8(include_bytes!("../../lisp/iterator.slosh"));
 const COLORS_LISP: &str = from_utf8(include_bytes!("../../lisp/sh-color.slosh"));
 pub const SLSHRC: &str = from_utf8(include_bytes!("../../init.slosh"));
 
@@ -89,6 +89,7 @@ pub fn load_internal(vm: &mut SloshVm, name: &'static str) -> VMResult<Value> {
             Ok(file) => Reader::from_file(file, vm, name, 1, 0),
             Err(e) => match name {
                 "core.slosh" => Reader::from_static_string(CORE_LISP, vm, name, 1, 0),
+                "iterator.slosh" => Reader::from_static_string(ITER_LISP, vm, name, 1, 0),
                 "sh-color.slosh" => Reader::from_static_string(COLORS_LISP, vm, name, 1, 0),
                 "init.slosh" => Reader::from_static_string(SLSHRC, vm, name, 1, 0),
                 _ => {
@@ -98,6 +99,7 @@ pub fn load_internal(vm: &mut SloshVm, name: &'static str) -> VMResult<Value> {
         },
         Err(e) => match name {
             "core.slosh" => Reader::from_static_string(CORE_LISP, vm, name, 1, 0),
+            "iterator.slosh" => Reader::from_static_string(ITER_LISP, vm, name, 1, 0),
             "sh-color.slosh" => Reader::from_static_string(COLORS_LISP, vm, name, 1, 0),
             "init.slosh" => Reader::from_static_string(SLSHRC, vm, name, 1, 0),
             _ => {

--- a/compiler/src/load_eval.rs
+++ b/compiler/src/load_eval.rs
@@ -579,7 +579,7 @@ Example:
         (set! tst-file (fopen tmp :read))
         (test::assert-equal '(1 2 3) (read tst-file))
         (test::assert-equal '(x y z) (read tst-file))
-        (test::assert-error (read test-file))
+        (test::assert-error (read tst-file))
         (fclose tst-file)
         (set! tst-file (fopen tmp :read))
         (test::assert-equal '(1 2 3) (read tst-file :done))

--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -701,8 +701,7 @@ Section: test
 Example:
 (test::assert-error-msg (err "error thrown") :error "error thrown")
 %#
-(defmacro assert-error-msg
-  (form key msg)
+(defmacro assert-error-msg (form key msg)
     `((fn (ret) (test::assert-true (and (= ~key (car ret)) (= ~msg (cdr ret)))
          (str ". Expected \n" ~key ", [" ~msg "]\n => Test returned:\n" (car ret) ", [" (cdr ret) "]")))
         (get-error ~form)))

--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -608,14 +608,15 @@ Asserts the two values are identical.
 Section: test
 %#
 (defmacro assert-equal (expected-val right-val & body)
-    `(if (= ~expected-val ~right-val)
-        #t
-        (let (ev (type ~expected-val)
-              rv (type ~right-val)
-              assert-err (mk-err :assert (str "Expected: " ~expected-val " " ev ", Got: " ~right-val " " rv "." ~@body)))
-        (do
-            (prn assert-err)
-            (err assert-err)))))
+    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
+        (if (= expected-val right-val)
+            #t
+            (let (ev (type expected-val)
+                  rv (type right-val)
+                  assert-err (mk-err :assert (str "Expected: " expected-val " " ev ", Got: " right-val " " rv "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
 
 #%
 Asserts the two values are identical.
@@ -630,14 +631,15 @@ Asserts the two values are not identical.
 Section: test
 %#
 (defmacro assert-not-equal (expected-val right-val & body)
-    `(if (not (= ~expected-val ~right-val))
-        #t
-        (let (ev (type ~expected-val)
-              rv (type ~right-val)
-              assert-err (mk-err :assert (str "Did not expect: " ~expected-val " " ev ", but got a matching: " ~right-val " " rv "." ~@body)))
-        (do
-            (prn assert-err)
-            (err assert-err)))))
+    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
+        (if (not (= expected-val right-val))
+            #t
+            (let (ev (type expected-val)
+                  rv (type right-val)
+                  assert-err (mk-err :assert (str "Did not expect: " expected-val " " ev ", but got a matching: " right-val " " rv "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
 
 #%
 Asserts the two values are not identical.
@@ -680,11 +682,13 @@ Asserts the value is an error
 Section: test
 %#
 (defmacro assert-error (val & body)
-(if `(err? ~val)
-    #t
-    (mk-err
-        :assert
-        `(str "Expected error got: " ~val "." ~@body))))
+    `(let (val (get-error ~val))
+        (if (not (= (car val) :ok))
+            #t
+            (let (assert-err (mk-err :assert (str "Expected error got: " (cdr val) "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
 
 #%
 Asserts the value is an error

--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -143,6 +143,22 @@ True if the to-test can be called as the first argument in an expression.
                                              (identical? t :Pair)))))
 
 #%
+Usage: (io? expression)
+
+True if the expression is an IO object (file), false otherwise.
+
+Section: type
+
+Example:
+(def iotst (fopen "/tmp/iotst" :create))
+(test::assert-true (io? iotst))
+(test::assert-false (io? 1))
+(test::assert-false (io? '(1 2 3)))
+(test::assert-false (io? (list)))
+%#
+(def io? (fn (v) (identical? (type v) :Io)))
+
+#%
 Usage: (defmacro name doc_string? argument_list body)
 
 Create a macro and bind it to a symbol in the current scope.
@@ -856,3 +872,5 @@ Example:
  %#
   (defmacro substitute (lst old-item new-item & mods)
        `(nsubstitute! (to-list ~lst) ~old-item ~new-item ~@mods))
+
+(load "iterator.slosh")

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -30,6 +30,48 @@ Example:
         (mk-iter (if (< idx vlen) (let (tmp idx) (inc! idx) v.~tmp) :*iter-empty*))))
 
 #%
+Iterator produces a vector in reverse.
+
+Section: iterator
+
+Example:
+(let (test-vec-iter (vec-iter-rev [1 2 3]))
+    (assert-equal 3 (test-vec-iter))
+    (assert-equal 2 (test-vec-iter))
+    (assert-equal 1 (test-vec-iter))
+    (assert-equal :*iter-empty* (test-vec-iter))
+    (set! test-vec-iter (vec-iter-rev (vec)))
+    (assert-equal :*iter-empty* (test-vec-iter)))
+%#
+(defn vec-iter-rev (v)
+    (let (idx (len v))
+        (mk-iter (if (> idx 0) (do (dec! idx) v.~idx) :*iter-empty*))))
+
+#%
+Return a pair of iterators, one forward and one reverse for a vector.
+The two iterators will not overlap (i.e. the forward and reverse will never
+produce the same items).
+
+Section: iterator
+
+Example:
+(let ([fwd-iter, rev-iter] (vec-iter-pair [1 2 3]))
+    (assert-equal 1 (fwd-iter))
+    (assert-equal 3 (rev-iter))
+    (assert-equal 2 (fwd-iter))
+    (assert-equal :*iter-empty* (rev-iter))
+    (assert-equal :*iter-empty* (fwd-iter)))
+(let ([fwd-iter, rev-iter] (vec-iter-pair (vec)))
+    (assert-equal :*iter-empty* (fwd-iter))
+    (assert-equal :*iter-empty* (rev-iter)))
+%#
+(defn vec-iter-pair (v)
+    (let (fidx 0, bidx (len v))
+        (cons
+            (mk-iter (if (< fidx bidx) (let (tmp fidx) (inc! fidx) v.~tmp) :*iter-empty*))
+            (mk-iter (if (> bidx fidx) (do (dec! bidx) v.~bidx) :*iter-empty*)))))
+
+#%
 Iterator that wraps a list.
 
 Section: iterator
@@ -47,7 +89,7 @@ Example:
     (mk-iter (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
 
 #%
-Iterator that wraps a file.  Each call to next! returns the next line (with
+Iterator that wraps a file.  Each call produces the next line (with
 trailing newline).
 
 Section: iterator

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -1,0 +1,240 @@
+#%
+Iterator that wraps a vector.
+
+Section: iterator
+
+Example:
+(def test-vec-iter (vec-iter [1 2 3]))
+(assert-equal 1 (test-vec-iter))
+(assert-equal 2 (test-vec-iter))
+(assert-equal 3 (test-vec-iter))
+(assert-equal :*iter-empty* (test-vec-iter))
+(def test-vec-iter (vec-iter (vec)))
+(assert-equal :*iter-empty* (test-vec-iter))
+%#
+(defn vec-iter (v)
+    (let (idx 0
+          vlen (len v)
+          next (fn () (if (< idx vlen) (let (tmp idx) (inc! idx) v.~tmp) :*iter-empty*)))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Iterator that wraps a list.
+
+Section: iterator
+
+Example:
+(def test-list-iter (list-iter '(1 2 3)))
+(assert-equal 1 (test-list-iter))
+(assert-equal 2 (test-list-iter))
+(assert-equal 3 (test-list-iter))
+(assert-equal :*iter-empty* (test-list-iter))
+(def test-list-iter (list-iter '()))
+(assert-equal :*iter-empty* (test-list-iter))
+%#
+(defn list-iter (l)
+    (let (next (fn () (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Iterator that wraps a file.  Each call to next! returns the next line (with
+trailing newline).
+
+Section: iterator
+
+Example:
+(def tst-file (fopen "/tmp/file-iter-test.txt" :create :truncate))
+(fprn tst-file "line 1")
+(fprn tst-file "line 2")
+(fprn tst-file "line 3")
+(fpr tst-file "line 4")
+(fclose tst-file)
+(def test-iter (file-iter (fopen "/tmp/file-iter-test.txt")))
+(assert-equal "line 1\\n" (test-iter))
+(assert-equal "line 2\\n" (test-iter))
+(assert-equal "line 3\\n" (test-iter))
+(assert-equal "line 4" (test-iter))
+(assert-equal :*iter-empty* (test-iter))
+%#
+(defn file-iter (f)
+    (let (next (fn () (let (line (read-line f))(if line line :*iter-empty*))))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Iterator that wraps a string.  Each element is the next character.
+
+Section: iterator
+
+Example:
+(def test-string-iter (string-iter "123"))
+(assert-equal \\1 (test-string-iter))
+(assert-equal \\2 (test-string-iter))
+(assert-equal \\3 (test-string-iter))
+(assert-equal :*iter-empty* (test-string-iter))
+%#
+(defn string-iter (s)
+    (let (idx 0
+          slen (len s)
+          next (fn () (if (< idx slen) (let (tmp idx) (inc! idx) s.~tmp) :*iter-empty*)))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Return true if thing is an iterator, false otherwise.
+
+Section: iterator
+
+Example:
+(assert-true (iter? (list-iter '(1 2 3))))
+(assert-false (iter? '(1 2 3)))
+%#
+(defn iter? (test)
+    (if (get-prop test :is-iter) #t #f))
+
+#%
+Iterator that wraps and returns a single object once.
+
+Section: iterator
+
+Example:
+(def test-iter (once-iter 3))
+(assert-equal 3 (test-iter))
+(assert-equal :*iter-empty* (test-iter))
+(def test-iter (once-iter "iter"))
+(assert-equal "iter" (test-iter))
+(assert-equal :*iter-empty* (test-iter))
+%#
+(defn once-iter (i)
+    (let (next (fn () (let (val i) (set! i :*iter-empty*) val)))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Iterator that wraps and returns a single object on each call.
+
+Section: iterator
+
+Example:
+(def test-iter (repeat-iter 3))
+(assert-equal 3 (test-iter))
+(assert-equal 3 (test-iter))
+(assert-equal 3 (test-iter))
+(assert-equal 3 (test-iter))
+(assert-equal 3 (test-iter))
+(def test-iter (repeat-iter "iter"))
+(assert-equal "iter" (test-iter))
+(assert-equal "iter" (test-iter))
+(assert-equal "iter" (test-iter))
+(assert-equal "iter" (test-iter))
+(assert-equal "iter" (test-iter))
+%#
+(defn repeat-iter (i)
+    (let (next (fn () i))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Return thing as an iterator if possible (if it is an iterator just return thing).
+
+Section: iterator
+
+Example:
+(assert-true (iter? (iter '(1 2 3))))
+(assert-true (iter? (iter [1 2 3])))
+(assert-true (iter? (iter "abc")))
+(assert-true (iter? (iter (iter '(1 2 3)))))
+%#
+(defn iter (thing)
+  (if (iter? thing)
+        thing
+      (list? thing)
+        (list-iter thing)
+      (vec? thing)
+        (vec-iter thing)
+      (string? thing)
+        (string-iter thing)
+      (io? thing)
+        (file-iter thing)
+      (err "iter: requires a list, vector, string, file or existing iterator")))
+
+#%
+Return thing as an iterator if possible (if it is an iterator just return thing).
+If not possible then wrap thing in a once iter and return that.
+
+Section: iterator
+
+Example:
+(assert-true (iter? (iter-or-single '(1 2 3))))
+(assert-true (iter? (iter-or-single [1 2 3])))
+(assert-true (iter? (iter-or-single "abc")))
+(assert-true (iter? (iter-or-single (iter '(1 2 3)))))
+(assert-true (iter? (iter-or-single 1)))
+(assert-true (iter? (iter-or-single \\A)))
+%#
+(defn iter-or-single (thing)
+  (if (iter? thing)
+        thing
+      (list? thing)
+        (list-iter thing)
+      (vec? thing)
+        (vec-iter thing)
+      (string? thing)
+        (string-iter thing)
+      (io? thing)
+        (file-iter thing)
+      (once-iter thing)))
+
+#%
+Iterator that generates numbers within a range.
+
+Section: iterator
+
+Example:
+(def test-iter (range 3 6))
+(assert-equal 3 (test-iter))
+(assert-equal 4 (test-iter))
+(assert-equal 5 (test-iter))
+(assert-equal :*iter-empty* (test-iter))
+%#
+(defn range (start end)
+    (let (next (fn () (if (< start end) (let (tmp start) (inc! start) tmp) :*iter-empty*)))
+        (set-prop next :is-iter #t)
+        next))
+
+#%
+Loops over each element in an iterator.  Will call iter on the input object.
+bind is bound to the current element of items and is accesible
+in body. Body is evaluated a number of times equal to the items in the iterator.
+
+Section: iterator
+
+Example:
+(def i 0)
+(for x in (range 0 11) (set! i (+ 1 i)))
+(assert-equal 11 i)
+%#
+(defmacro for (bind in items & body)
+    (if (not (= in 'in)) (err "Invalid for: (for [i] in [iterator] (body))"))
+    (let (i-name (gensym))
+    `(let-while (~i-name ~items)(~bind (~i-name)) (not (identical? ~bind :*iter-empty*)) ~@body)))
+
+#%
+Iterator that applies a lambda to each element of another iterator- is lazy.
+
+Section: iterator
+
+Example:
+(def test-map-iter (map (list-iter '(1 2 3)) (fn (x) (* x 2))))
+(assert-equal 2 (test-map-iter))
+(assert-equal 4 (test-map-iter))
+(assert-equal 6 (test-map-iter))
+(assert-equal :*iter-empty* (test-map-iter))
+%#
+(defn map (i lambda)
+    (let (next (fn () (let (val (i)) (if (identical? val :*iter-empty*) :*iter-empty* (lambda val)))))
+        (set-prop next :is-iter #t)
+        next))
+

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -1,4 +1,17 @@
 #%
+Helper to create an iterator.  Will make sure it has the correct
+property set.
+
+Section: iterator
+
+Example:
+%#
+(defmacro mk-iter (& body)
+    `(let (iter (fn () ~@body))
+        (set-prop iter :is-iter #t)
+        iter))
+
+#%
 Iterator that wraps a vector.
 
 Section: iterator
@@ -13,11 +26,8 @@ Example:
 (assert-equal :*iter-empty* (test-vec-iter))
 %#
 (defn vec-iter (v)
-    (let (idx 0
-          vlen (len v)
-          next (fn () (if (< idx vlen) (let (tmp idx) (inc! idx) v.~tmp) :*iter-empty*)))
-        (set-prop next :is-iter #t)
-        next))
+    (let (idx 0, vlen (len v))
+        (mk-iter (if (< idx vlen) (let (tmp idx) (inc! idx) v.~tmp) :*iter-empty*))))
 
 #%
 Iterator that wraps a list.
@@ -34,9 +44,7 @@ Example:
 (assert-equal :*iter-empty* (test-list-iter))
 %#
 (defn list-iter (l)
-    (let (next (fn () (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
 
 #%
 Iterator that wraps a file.  Each call to next! returns the next line (with
@@ -59,9 +67,7 @@ Example:
 (assert-equal :*iter-empty* (test-iter))
 %#
 (defn file-iter (f)
-    (let (next (fn () (let (line (read-line f))(if line line :*iter-empty*))))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter (let (line (read-line f))(if line line :*iter-empty*))))
 
 #%
 Iterator that wraps a string.  Each element is the next character.
@@ -76,11 +82,8 @@ Example:
 (assert-equal :*iter-empty* (test-string-iter))
 %#
 (defn string-iter (s)
-    (let (idx 0
-          slen (len s)
-          next (fn () (if (< idx slen) (let (tmp idx) (inc! idx) s.~tmp) :*iter-empty*)))
-        (set-prop next :is-iter #t)
-        next))
+    (let (idx 0, slen (len s))
+        (mk-iter (if (< idx slen) (let (tmp idx) (inc! idx) s.~tmp) :*iter-empty*))))
 
 #%
 Return true if thing is an iterator, false otherwise.
@@ -108,9 +111,7 @@ Example:
 (assert-equal :*iter-empty* (test-iter))
 %#
 (defn once-iter (i)
-    (let (next (fn () (let (val i) (set! i :*iter-empty*) val)))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter (let (val i) (set! i :*iter-empty*) val)))
 
 #%
 Iterator that wraps and returns a single object on each call.
@@ -132,9 +133,7 @@ Example:
 (assert-equal "iter" (test-iter))
 %#
 (defn repeat-iter (i)
-    (let (next (fn () i))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter i))
 
 #%
 Return thing as an iterator if possible (if it is an iterator just return thing).
@@ -200,9 +199,7 @@ Example:
 (assert-equal :*iter-empty* (test-iter))
 %#
 (defn range (start end)
-    (let (next (fn () (if (< start end) (let (tmp start) (inc! start) tmp) :*iter-empty*)))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter (if (< start end) (let (tmp start) (inc! start) tmp) :*iter-empty*)))
 
 #%
 Loops over each element in an iterator.  Will call iter on the input object.
@@ -234,7 +231,5 @@ Example:
 (assert-equal :*iter-empty* (test-map-iter))
 %#
 (defn map (i lambda)
-    (let (next (fn () (let (val (i)) (if (identical? val :*iter-empty*) :*iter-empty* (lambda val)))))
-        (set-prop next :is-iter #t)
-        next))
+    (mk-iter (let (val (i)) (if (identical? val :*iter-empty*) :*iter-empty* (lambda val)))))
 

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -17,13 +17,13 @@ Iterator that wraps a vector.
 Section: iterator
 
 Example:
-(def test-vec-iter (vec-iter [1 2 3]))
-(assert-equal 1 (test-vec-iter))
-(assert-equal 2 (test-vec-iter))
-(assert-equal 3 (test-vec-iter))
-(assert-equal :*iter-empty* (test-vec-iter))
-(def test-vec-iter (vec-iter (vec)))
-(assert-equal :*iter-empty* (test-vec-iter))
+(let (test-vec-iter (vec-iter [1 2 3]))
+    (assert-equal 1 (test-vec-iter))
+    (assert-equal 2 (test-vec-iter))
+    (assert-equal 3 (test-vec-iter))
+    (assert-equal :*iter-empty* (test-vec-iter))
+    (set! test-vec-iter (vec-iter (vec)))
+    (assert-equal :*iter-empty* (test-vec-iter)))
 %#
 (defn vec-iter (v)
     (let (idx 0, vlen (len v))
@@ -35,13 +35,13 @@ Iterator that wraps a list.
 Section: iterator
 
 Example:
-(def test-list-iter (list-iter '(1 2 3)))
-(assert-equal 1 (test-list-iter))
-(assert-equal 2 (test-list-iter))
-(assert-equal 3 (test-list-iter))
-(assert-equal :*iter-empty* (test-list-iter))
-(def test-list-iter (list-iter '()))
-(assert-equal :*iter-empty* (test-list-iter))
+(let (test-list-iter (list-iter '(1 2 3)))
+    (assert-equal 1 (test-list-iter))
+    (assert-equal 2 (test-list-iter))
+    (assert-equal 3 (test-list-iter))
+    (assert-equal :*iter-empty* (test-list-iter))
+    (set! test-list-iter (list-iter '()))
+    (assert-equal :*iter-empty* (test-list-iter)))
 %#
 (defn list-iter (l)
     (mk-iter (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
@@ -53,18 +53,20 @@ trailing newline).
 Section: iterator
 
 Example:
-(def tst-file (fopen "/tmp/file-iter-test.txt" :create :truncate))
-(fprn tst-file "line 1")
-(fprn tst-file "line 2")
-(fprn tst-file "line 3")
-(fpr tst-file "line 4")
-(fclose tst-file)
-(def test-iter (file-iter (fopen "/tmp/file-iter-test.txt")))
-(assert-equal "line 1\\n" (test-iter))
-(assert-equal "line 2\\n" (test-iter))
-(assert-equal "line 3\\n" (test-iter))
-(assert-equal "line 4" (test-iter))
-(assert-equal :*iter-empty* (test-iter))
+(with-temp-file (fn (file-name)
+    (let (tst-file (fopen file-name :create :truncate))
+        (defer (fclose tst-file))
+        (fprn tst-file "line 1")
+        (fprn tst-file "line 2")
+        (fprn tst-file "line 3")
+        (fpr tst-file "line 4"))
+    (let (tst-file (fopen file-name), test-iter (file-iter tst-file))
+        (defer (fclose tst-file))
+        (assert-equal "line 1\\n" (test-iter))
+        (assert-equal "line 2\\n" (test-iter))
+        (assert-equal "line 3\\n" (test-iter))
+        (assert-equal "line 4" (test-iter))
+        (assert-equal :*iter-empty* (test-iter)))))
 %#
 (defn file-iter (f)
     (mk-iter (let (line (read-line f))(if line line :*iter-empty*))))
@@ -75,11 +77,11 @@ Iterator that wraps a string.  Each element is the next character.
 Section: iterator
 
 Example:
-(def test-string-iter (string-iter "123"))
-(assert-equal \\1 (test-string-iter))
-(assert-equal \\2 (test-string-iter))
-(assert-equal \\3 (test-string-iter))
-(assert-equal :*iter-empty* (test-string-iter))
+(let (test-string-iter (string-iter "123"))
+    (assert-equal \\1 (test-string-iter))
+    (assert-equal \\2 (test-string-iter))
+    (assert-equal \\3 (test-string-iter))
+    (assert-equal :*iter-empty* (test-string-iter)))
 %#
 (defn string-iter (s)
     (let (idx 0, slen (len s))
@@ -103,12 +105,12 @@ Iterator that wraps and returns a single object once.
 Section: iterator
 
 Example:
-(def test-iter (once-iter 3))
-(assert-equal 3 (test-iter))
-(assert-equal :*iter-empty* (test-iter))
-(def test-iter (once-iter "iter"))
-(assert-equal "iter" (test-iter))
-(assert-equal :*iter-empty* (test-iter))
+(let (test-iter (once-iter 3))
+    (assert-equal 3 (test-iter))
+    (assert-equal :*iter-empty* (test-iter))
+    (set! test-iter (once-iter "iter"))
+    (assert-equal "iter" (test-iter))
+    (assert-equal :*iter-empty* (test-iter)))
 %#
 (defn once-iter (i)
     (mk-iter (let (val i) (set! i :*iter-empty*) val)))
@@ -119,18 +121,18 @@ Iterator that wraps and returns a single object on each call.
 Section: iterator
 
 Example:
-(def test-iter (repeat-iter 3))
-(assert-equal 3 (test-iter))
-(assert-equal 3 (test-iter))
-(assert-equal 3 (test-iter))
-(assert-equal 3 (test-iter))
-(assert-equal 3 (test-iter))
-(def test-iter (repeat-iter "iter"))
-(assert-equal "iter" (test-iter))
-(assert-equal "iter" (test-iter))
-(assert-equal "iter" (test-iter))
-(assert-equal "iter" (test-iter))
-(assert-equal "iter" (test-iter))
+(let (test-iter (repeat-iter 3))
+    (assert-equal 3 (test-iter))
+    (assert-equal 3 (test-iter))
+    (assert-equal 3 (test-iter))
+    (assert-equal 3 (test-iter))
+    (assert-equal 3 (test-iter))
+    (set! test-iter (repeat-iter "iter"))
+    (assert-equal "iter" (test-iter))
+    (assert-equal "iter" (test-iter))
+    (assert-equal "iter" (test-iter))
+    (assert-equal "iter" (test-iter))
+    (assert-equal "iter" (test-iter)))
 %#
 (defn repeat-iter (i)
     (mk-iter i))
@@ -192,11 +194,11 @@ Iterator that generates numbers within a range.
 Section: iterator
 
 Example:
-(def test-iter (range 3 6))
-(assert-equal 3 (test-iter))
-(assert-equal 4 (test-iter))
-(assert-equal 5 (test-iter))
-(assert-equal :*iter-empty* (test-iter))
+(let (test-iter (range 3 6))
+    (assert-equal 3 (test-iter))
+    (assert-equal 4 (test-iter))
+    (assert-equal 5 (test-iter))
+    (assert-equal :*iter-empty* (test-iter)))
 %#
 (defn range (start end)
     (mk-iter (if (< start end) (let (tmp start) (inc! start) tmp) :*iter-empty*)))
@@ -209,9 +211,9 @@ in body. Body is evaluated a number of times equal to the items in the iterator.
 Section: iterator
 
 Example:
-(def i 0)
-(for x in (range 0 11) (set! i (+ 1 i)))
-(assert-equal 11 i)
+(let (i 0)
+    (for x in (range 0 11) (set! i (+ 1 i)))
+    (assert-equal 11 i))
 %#
 (defmacro for (bind in items & body)
     (if (not (= in 'in)) (err "Invalid for: (for [i] in [iterator] (body))"))
@@ -224,11 +226,11 @@ Iterator that applies a lambda to each element of another iterator- is lazy.
 Section: iterator
 
 Example:
-(def test-map-iter (map (list-iter '(1 2 3)) (fn (x) (* x 2))))
-(assert-equal 2 (test-map-iter))
-(assert-equal 4 (test-map-iter))
-(assert-equal 6 (test-map-iter))
-(assert-equal :*iter-empty* (test-map-iter))
+(let (test-map-iter (map (list-iter '(1 2 3)) (fn (x) (* x 2))))
+    (assert-equal 2 (test-map-iter))
+    (assert-equal 4 (test-map-iter))
+    (assert-equal 6 (test-map-iter))
+    (assert-equal :*iter-empty* (test-map-iter)))
 %#
 (defn map (i lambda)
     (mk-iter (let (val (i)) (if (identical? val :*iter-empty*) :*iter-empty* (lambda val)))))

--- a/vm/src/heap.rs
+++ b/vm/src/heap.rs
@@ -549,7 +549,7 @@ impl Heap {
         }
     }
 
-    fn mark_call_frame(&mut self, call_frame: &CallFrame) {
+    pub fn mark_call_frame(&mut self, call_frame: &CallFrame) {
         self.mark_chunk(&call_frame.chunk);
         if let Some(this_fn) = call_frame.this_fn {
             self.mark_trace(this_fn);
@@ -639,7 +639,7 @@ impl Heap {
                 let k = self
                     .continuations
                     .get(handle.idx())
-                    .expect("Invalid error handle!")
+                    .expect("Invalid continuation handle!")
                     .clone();
                 self.mark_call_frame(&k.frame);
                 for obj in &k.stack {

--- a/vm/src/vm/call.rs
+++ b/vm/src/vm/call.rs
@@ -159,7 +159,7 @@ impl<ENV> GVm<ENV> {
                             // We should be OK making the frame here only when needed.  If a builtin
                             // calls bytecode it should be using do_call() which will restore state.
                             let frame = self.make_call_frame(chunk.clone(), lambda, false);
-                            self.pause_gc(); // We might have allocated incoming parms that are not rooted yet (see the CCC opcode for instance).
+                            self.pause_gc(); // We might have allocated incoming params that are not rooted yet (see the CCC opcode for instance).
                             let call_frame = self.alloc_callframe(frame);
                             self.unpause_gc();
                             mov_register!(self, first_reg as usize, call_frame);
@@ -178,7 +178,7 @@ impl<ENV> GVm<ENV> {
                 }
                 if !tail_call {
                     let frame = self.make_call_frame(chunk, lambda, true);
-                    self.pause_gc(); // We might have allocated incoming parms that are not rooted yet (see the CCC opcode for instance).
+                    self.pause_gc(); // We might have allocated incoming params that are not rooted yet (see the CCC opcode for instance).
                     let aframe = self.alloc_callframe(frame);
                     self.unpause_gc();
                     mov_register!(self, first_reg as usize, aframe);
@@ -224,7 +224,7 @@ impl<ENV> GVm<ENV> {
                 self.this_fn = Some(lambda);
                 self.ip_ptr = get_code!(l);
                 if let Some(frame) = frame {
-                    self.pause_gc(); // We might have allocated incoming parms that are not rooted yet (see the CCC opcode for instance).
+                    self.pause_gc(); // We might have allocated incoming params that are not rooted yet (see the CCC opcode for instance).
                     let aframe = self.alloc_callframe(frame);
                     self.unpause_gc();
                     *self.stack_mut(stack_top + first_reg as usize) = aframe;

--- a/vm/src/vm/exec_loop.rs
+++ b/vm/src/vm/exec_loop.rs
@@ -146,7 +146,7 @@ impl<ENV> GVm<ENV> {
             iter.rev().nth(((0 - idx) - 1) as usize)
         };
         let v = if let Some(ch) = ch {
-            // borrow checker won;t let us use self.alloc_char(ch) here....
+            // borrow checker won't let us use self.alloc_char(ch) here....
             let len = ch.len();
             if len <= 6 {
                 let mut b = [0_u8; 6];
@@ -157,7 +157,7 @@ impl<ENV> GVm<ENV> {
                 Value::CharClusterLong(h.get_handle().expect("just allocated, missing handle!"))
             }
         } else {
-            return Err(VMError::new_vm("GET: Index out of range."));
+            self.make_err("vm-missing", idx.into())
         };
         Ok(v)
     }

--- a/vm/src/vm/storage.rs
+++ b/vm/src/vm/storage.rs
@@ -425,8 +425,9 @@ impl<ENV> GVm<ENV> {
             heap.mark(on_error);
         }
         // TODO: XXX do we need this?  Probably but maybe not.
-        //if let Some(err_frame) = &self.err_frame {
-        //}
+        if let Some(err_frame) = &self.err_frame {
+            heap.mark_call_frame(err_frame);
+        }
         for defer in &self.defers {
             heap.mark(*defer);
         }


### PR DESCRIPTION
This also fixes a GC bug, asserts could double eval forms on failure and assert-error was broken.  Fixed some tests that only passed because assert-error was broken.

This is just the iterator start, needs a lot of stuff (filter, reduce, etc) but with bugfixes want to go ahead and get it in expand later.
The new iterators are a LOT simpler than in slush...