### PR TITLE
Initial namespace support.

### DIFF
--- a/builtins/src/collections.rs
+++ b/builtins/src/collections.rs
@@ -152,10 +152,10 @@ pub fn occurs(environment: &mut SloshVm, haystack: Value, needle: Value) -> VMRe
 /// Section: collection
 ///
 /// Example:
-/// (assert-true (in? [1 2 3 4 5] 3))
-/// (assert-false (in? [1 2 3 4 5] 9))
-/// (assert-true (in? (list 1 2 3 4 5) 3))
-/// (assert-true (in? '(1 2 3 4 5) 5))
+/// (test::assert-true (in? [1 2 3 4 5] 3))
+/// (test::assert-false (in? [1 2 3 4 5] 9))
+/// (test::assert-true (in? (list 1 2 3 4 5) 3))
+/// (test::assert-true (in? '(1 2 3 4 5) 5))
 #[sl_sh_fn(fn_name = "in?", takes_env = true)]
 pub fn is_in(environment: &mut SloshVm, haystack: Value, needle: Value) -> VMResult<Value> {
     let mut stack = vec![];
@@ -254,12 +254,12 @@ pub fn flatten(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
 ///
 /// Example:
 /// (let (tmap [1 2 3 0])
-///     (assert-false (empty? tmap))
+///     (test::assert-false (empty? tmap))
 ///     (set! tmap (reverse tmap))
-///     (assert-equal 2 (get tmap 2))
-///     (assert-equal 1 (get tmap 3))
-///     (assert-equal 0 (get tmap 0))
-///     (assert-error (reverse "string")))
+///     (test::assert-equal 2 (get tmap 2))
+///     (test::assert-equal 1 (get tmap 3))
+///     (test::assert-equal 0 (get tmap 0))
+///     (test::assert-error (reverse "string")))
 #[sl_sh_fn(fn_name = "reverse", takes_env = true)]
 pub fn reverse(environment: &mut SloshVm, seq: Value) -> VMResult<Value> {
     match seq {
@@ -332,10 +332,10 @@ it into one vector of values.
 Section: collection
 
 Example:
-(assert-equal [1 2 3 1 2 3] (flatten 1 2 3 (list 1 2 3)))
-(assert-equal [1 2 3 1 2 3] (flatten 1 2 3 [1 2 3]))
-(assert-equal [1 2 3 1 2] (flatten 1 2 3 (list 1 2)))
-(assert-equal [1 2 3 1 2 3 1 2] (flatten 1 2 3 (list 1 2 3 (list 1 2))))
+(test::assert-equal [1 2 3 1 2 3] (flatten 1 2 3 (list 1 2 3)))
+(test::assert-equal [1 2 3 1 2 3] (flatten 1 2 3 [1 2 3]))
+(test::assert-equal [1 2 3 1 2] (flatten 1 2 3 (list 1 2)))
+(test::assert-equal [1 2 3 1 2 3 1 2] (flatten 1 2 3 (list 1 2 3 (list 1 2))))
 ",
     );
     add_builtin(

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -191,7 +191,6 @@ Remainder from dividing first int by the second.
 Section: math
 
 Example:
-(ns-import 'math)
 (test::assert-equal 0 (rem 50 10))
 (test::assert-equal 5 (rem 55 10))
 (test::assert-equal 1 (rem 1 2))

--- a/builtins/src/print.rs
+++ b/builtins/src/print.rs
@@ -153,7 +153,7 @@ pub fn fprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     } else {
         Err(VMError::new(
             "io",
-            "fpr: require a writable IO object as first parameter",
+            "fprn: require a writable IO object as first parameter",
         ))
     }
 }

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1399,6 +1399,24 @@ impl SloshVmTrait for SloshVm {
             }
             None
         }
+        fn is_alias(alias: &str, sym: &str) -> bool {
+            let mut a_i = alias.chars();
+            let mut s_i = sym.chars().peekable();
+            let mut is_alias = true;
+            while let (Some(ach), Some(sch)) = (a_i.next(), s_i.peek()) {
+                if ach != *sch {
+                    is_alias = false;
+                    break;
+                }
+                s_i.next();
+            }
+            if is_alias {
+                if let (Some(':'), Some(':')) = (s_i.next(), s_i.next()) {
+                    return true;
+                }
+            }
+            false
+        }
 
         let sym = self.get_interned(symbol);
         if let Some(g) = check_global(self, &self.env().namespace.name, sym) {
@@ -1406,7 +1424,7 @@ impl SloshVmTrait for SloshVm {
         }
         for (import, alias) in &self.env().namespace.imports {
             if let Some(alias) = alias {
-                if sym.starts_with(alias) {
+                if is_alias(alias, sym) {
                     let s = sym.replacen(alias, import, 1);
                     if let Some(i) = self.get_if_interned(&s) {
                         if let Some(global) =

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1109,7 +1109,7 @@ Example:
 "#),
             import: add_special(vm, "import", r#"Usage: (import namespace [:as symbol])
 
-Will import a namespace.  Without an as then all symbols in the namespace will become available in the current
+Will import a namespace.  Without an :as then all symbols in the namespace will become available in the current
 namespace as if local.  With [:as symbol] then all namespace symbols become available with symbol:: prepended.
 
 Section: core

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1130,7 +1130,7 @@ Example:
 Read and eval a file (from path- a string).  The load special form executes at compile time.
 This means it's parameter must resolve at compile time.  Most of the time you will want to use
 this in conjuction with 'with-ns' to namespace the contents.
-Note: on it's own does noting with namespaces.
+Note: on it's own does nothing with namespaces.
 
 Section: core
 

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1078,7 +1078,7 @@ Example:
 
 Changes to namespace.  This is "open-ended" change and is intended for use with
 the REPL prefer with-ns for scripts.
-THe symbol "::" will return to the "root" namespace (i.e. no namespace prepended to globals).
+The symbol "::" will return to the "root" namespace (i.e. no namespace prepended to globals).
 This will cause all globals defined to have namespace:: prepended.
 This will also clear any existing imports.
 

--- a/compiler/src/compile/compile_call.rs
+++ b/compiler/src/compile/compile_call.rs
@@ -9,14 +9,16 @@ fn compile_params(
     result: usize,
     tail: bool,
 ) -> VMResult<()> {
-    for (i, r) in cdr.iter().enumerate() {
-        compile(env, state, *r, result + i)?;
-    }
-    let line = env.own_line();
-    if tail {
-        state
-            .chunk
-            .encode3(BMOV, 1, result as u16, cdr.len() as u16, line)?;
+    if !cdr.is_empty() {
+        for (i, r) in cdr.iter().enumerate() {
+            compile(env, state, *r, result + i)?;
+        }
+        let line = env.own_line();
+        if tail {
+            state
+                .chunk
+                .encode3(BMOV, 1, result as u16, cdr.len() as u16, line)?;
+        }
     }
     Ok(())
 }

--- a/compiler/src/reader.rs
+++ b/compiler/src/reader.rs
@@ -515,7 +515,6 @@ impl<'vm> Reader<'vm> {
                         symbol.push(res);
                     }
                     _ => {
-                        println!("XXXXX pushing {ch}");
                         symbol.push_str(&ch);
                     }
                 }

--- a/compiler/src/reader.rs
+++ b/compiler/src/reader.rs
@@ -515,6 +515,7 @@ impl<'vm> Reader<'vm> {
                         symbol.push(res);
                     }
                     _ => {
+                        println!("XXXXX pushing {ch}");
                         symbol.push_str(&ch);
                     }
                 }

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,4 +1,3 @@
 book
 src/rust-docs
 src/legacy
-*.md

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -7,4 +7,5 @@
 # General
 
 - [Let Bindings and Destructuring](./let.md)
+- [Namespaces](./namespaces.md)
 - [Examples](./end_to_end.md)

--- a/doc/src/namespaces.md
+++ b/doc/src/namespaces.md
@@ -1,0 +1,50 @@
+# Namespaces
+
+## Description
+
+Namespaces are compiler bookkeeping for organizing global symobols.  When in a namespace then any symbols that are defined will have the current NAMESPACE:: prepended to the symbol.  When symbols are resolved the compiler will also try to prepend the current namespace first in order to find the symbol.
+
+## Entering a namespace
+
+From code use the 'with-ns' form.
+```slosh
+(doc 'with-ns)
+```
+
+From the top-level REPL you can use 'ns'.
+```slosh
+(doc 'ns)
+```
+
+This is an open-ended namespace change intended for the repl, prefer with-ns for a scoped namespace in code.
+
+## Imports
+
+Other namespaces can be imported to allow it's symbols to be accessed in a shorter form.  Use the 'import' form for this .
+```slosh
+(doc 'import)
+```
+For instance using ```(import iter)``` will allow any symbols in the iter namespace to be used without prepending 'iter::'.  You can also use the ```(import iter :as i)```, the :as form allows the namespace to be given a different name.  In this case the iter namespace could be replaced with 'i', (i::for ...) instead of (iter::for ...) for example.  Imports are resolved in the order they are compiled in case of conflict (i.e. the first import that resolves a symbol wins).  Imports are attached to the current namespace, changing namespaces will clear imports (note that 'with-ns' saves and restores the previous namespace with imports).
+
+## Loading code
+
+To load new code into your environemt use load or run-script.
+
+### Load
+
+The load form should generally be preferred.  It will compile the code at compile time (vs runtime) and execute it at runtime.  This means:
+- The path parameter has to be known at compile time: a string const, defined global or form that does not need local inputs.
+- Any symbols defined in the loaded code will be known to the compiler at compile time and available for use.
+
+```slosh
+(doc 'load)
+```
+
+### Run Script
+The run-script form loads each form in the file, compiles and executes it at runtime.  This means:
+- It can take any parameter since it is resolved at runtime.
+- Globals it defines will NOT be known until after it runs at runtime.
+
+```slosh
+(doc 'run-script)
+```

--- a/init.slosh
+++ b/init.slosh
@@ -3,9 +3,6 @@
 (prn "Using default slshrc written to \"~/.config/slosh/init.slosh\".")
 (prn "Edit this file to remove this message and customize your shell")
 
-; load the core lib
-(load "core.slosh")
-
 (defn parse-git-branch () (let (branch ($sh "git rev-parse --abbrev-ref HEAD 2>/dev/null"))
 	(if (= branch "")
 		(str "")

--- a/init.slosh
+++ b/init.slosh
@@ -23,8 +23,6 @@
         (str "\x1b[31m" status "\n\x1b[31m" debug "λ #\x1b[39m ")
         (str "\x1b[32m" status "\n\x1b[32m" debug "λ >\x1b[39m "))))
 
-(def *ns* "SLOSH")
-
 (defn __prompt ()
     (str "\x1b[32m[" *ns* "]:" (env "HOST") ":\x1b[34m" (str-trim! (get-pwd)) "/\x1b[37m" (parse-git-branch) (set-prompt-tail *last-status*)))
 

--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -114,9 +114,9 @@ Section: collection
 Return false if length of s is 0, true otherwise.
 
 Example:
-(assert-true (empty? nil))
-(assert-true (empty? []))
-(assert-false (empty? [1]))
+(test::assert-true (empty? nil))
+(test::assert-true (empty? []))
+(test::assert-false (empty? [1]))
 %#
 (def empty? (fn (v) (= (len v) 0)))
 
@@ -128,9 +128,9 @@ Section: collection
 Return true if length of s is not 0, false otherwise.
 
 Example:
-(assert-false (empty? nil))
-(assert-false (empty? []))
-(assert-true (empty? [1]))
+(test::assert-false (empty? nil))
+(test::assert-false (empty? []))
+(test::assert-true (empty? [1]))
 %#
 (def not-empty? (fn (v) (> (len v) 0)))
 
@@ -247,20 +247,20 @@ Example:
 (loop (idx) (3) (do
     (set! tot (+ tot 1))
     (if (> idx 1) (recur (- idx 1)))))
-(assert-equal 3 tot)
+(test::assert-equal 3 tot)
 (def tot 0)
 (loop (idx) (0)
     (set! tot (+ tot 1))
     (when (not (= idx 2))
         (recur (+ idx 1))))
-(assert-equal 3 tot)
-(assert-equal 11 (loop (idx) (0)
+(test::assert-equal 3 tot)
+(test::assert-equal 11 (loop (idx) (0)
     (if (= idx 2) (break 11))
     (recur (+ idx 1))))
-(assert-false (loop (idx) (0)
+(test::assert-false (loop (idx) (0)
     (if (= idx 2) (break nil))
     (recur (+ idx 1))))
-(assert-error (loop (idx) (0)
+(test::assert-error (loop (idx) (0)
     (if (= idx 2) (break 1 3))
     (recur (+ idx 1))))
 %#
@@ -289,7 +289,7 @@ Section: core
 Example:
 (def i 0)
 (dotimes 11 (set! i (+ 1 i)))
-(assert-equal 11 i)
+(test::assert-equal 11 i)
 %#
 (defmacro dotimes
     (times & body)
@@ -309,8 +309,8 @@ Example:
 (def i 0)
 (def i-tot 0)
 (dotimes-i idx 11 (do (set! i-tot (+ idx i-tot))(set! i (+ 1 i))))
-(assert-equal 11 i)
-(assert-equal 55 i-tot)
+(test::assert-equal 11 i)
+(test::assert-equal 55 i-tot)
 %#
 (defmacro dotimes-i
     (idx-bind times & body)
@@ -330,9 +330,9 @@ Section: conditional
 
 Example:
 
-(assert-true (when #t #t))
-(assert-false (when #t nil))
-(assert-false (when nil nil))
+(test::assert-true (when #t #t))
+(test::assert-false (when #t nil))
+(test::assert-false (when nil nil))
 %#
 (defmacro when
     (provided-condition if-true)
@@ -376,7 +376,7 @@ Section: core
 
 Example:
 
-(assert-equal 0 (identity 0))
+(test::assert-equal 0 (identity 0))
 %#
 (defn identity (x) x)
 
@@ -386,11 +386,11 @@ Produces the last element in a list or vector.  Nil if the list/vector is empty.
 Section: sequence
 
 Example:
-(assert-equal 3 (last '(1 2 3)))
-(assert-equal 3 (last [1 2 3]))
-(assert-equal nil (last '()))
-(assert-equal nil (last nil))
-(assert-equal nil (last []))
+(test::assert-equal 3 (last '(1 2 3)))
+(test::assert-equal 3 (last [1 2 3]))
+(test::assert-equal nil (last '()))
+(test::assert-equal nil (last nil))
+(test::assert-equal nil (last []))
 %#
 (defn last
   (obj)
@@ -409,13 +409,13 @@ Produces the provided list minus the last element.  Nil if the list is empty or 
 Section: sequence
 
 Example:
-(assert-equal '(1 2) (butlast '(1 2 3)))
-(assert-equal [1 2] (butlast [1 2 3]))
-(assert-equal nil (butlast '(1)))
-(assert-equal [] (butlast [1]))
-(assert-equal nil (butlast '()))
-(assert-equal nil (butlast nil))
-(assert-equal nil (butlast []))
+(test::assert-equal '(1 2) (butlast '(1 2 3)))
+(test::assert-equal [1 2] (butlast [1 2 3]))
+(test::assert-equal nil (butlast '(1)))
+(test::assert-equal [] (butlast [1]))
+(test::assert-equal nil (butlast '()))
+(test::assert-equal nil (butlast nil))
+(test::assert-equal nil (butlast []))
 %#
 (def butlast nil) ; predeclare and assign butlast to avoid a warning when used in butlast declaration.
 (defn butlast
@@ -438,11 +438,11 @@ vectors.
 Section: sequence
 
 Example:
-(assert-equal 1 (first '(1 2 3)))
-(assert-equal 1 (first [1 2 3]))
-(assert-equal nil (first '()))
-(assert-equal nil (first nil))
-(assert-equal [] (first []))
+(test::assert-equal 1 (first '(1 2 3)))
+(test::assert-equal 1 (first [1 2 3]))
+(test::assert-equal nil (first '()))
+(test::assert-equal nil (first nil))
+(test::assert-equal [] (first []))
 %#
 (defn first
   (obj)
@@ -460,13 +460,13 @@ Section: sequence
 
 
 Example:
-(assert-equal '(2 3) (rest '(1 2 3)))
-(assert-equal [2 3] (rest [1 2 3]))
-(assert-equal nil (rest '(1)))
-(assert-equal [] (rest [1]))
-(assert-equal nil (rest '()))
-(assert-equal nil (rest nil))
-(assert-equal [] (rest []))
+(test::assert-equal '(2 3) (rest '(1 2 3)))
+(test::assert-equal [2 3] (rest [1 2 3]))
+(test::assert-equal nil (rest '(1)))
+(test::assert-equal [] (rest [1]))
+(test::assert-equal nil (rest '()))
+(test::assert-equal nil (rest nil))
+(test::assert-equal [] (rest []))
 %#
 (defn rest
   (obj)
@@ -484,7 +484,7 @@ Section: sequence
 Example:
 (def i 0)
 (seq-for x in '(1 2 3 4 5 6) (set! i (+ 1 i)))
-(assert-equal 6 i)
+(test::assert-equal 6 i)
 %#
 (defmacro seq-for
   (bind in items & body)
@@ -513,16 +513,16 @@ Example:
              (3 (str \"opt\" \"-three\"))
              (nil \"default\")))
 (def b 0)
-(assert-equal b 0)
-(assert-equal \"opt-one\" (select-option 1))
-(assert-equal \"opt-two\" (select-option 2))
-(assert-equal b 5)
-(assert-equal \"opt-three\" (select-option 3))
-(assert-equal #f (select-option 4))
-(assert-equal \"opt-one\" (select-option-def 1))
-(assert-equal \"opt-two\" (select-option-def 2))
-(assert-equal \"opt-three\" (select-option-def 3))
-(assert-equal \"default\" (select-option-def 4))
+(test::assert-equal b 0)
+(test::assert-equal \"opt-one\" (select-option 1))
+(test::assert-equal \"opt-two\" (select-option 2))
+(test::assert-equal b 5)
+(test::assert-equal \"opt-three\" (select-option 3))
+(test::assert-equal #f (select-option 4))
+(test::assert-equal \"opt-one\" (select-option-def 1))
+(test::assert-equal \"opt-two\" (select-option-def 2))
+(test::assert-equal \"opt-three\" (select-option-def 3))
+(test::assert-equal \"default\" (select-option-def 4))
 %#
 (defmacro match
   (condition & branches)
@@ -560,16 +560,16 @@ Example:
           ((= a 2) \"opt-two\")
           ((= a 3) (str \"opt\" \"-three\"))
           (#t \"default\")))
-(assert-equal \"opt-one\" (select-option 1))
-(assert-equal b 0)
-(assert-equal \"opt-two\" (select-option 2))
-(assert-equal b 5)
-(assert-equal \"opt-three\" (select-option 3))
-(assert-equal nil (select-option 4))
-(assert-equal \"opt-one\" (select-option-def 1))
-(assert-equal \"opt-two\" (select-option-def 2))
-(assert-equal \"opt-three\" (select-option-def 3))
-(assert-equal \"default\" (select-option-def 4))
+(test::assert-equal \"opt-one\" (select-option 1))
+(test::assert-equal b 0)
+(test::assert-equal \"opt-two\" (select-option 2))
+(test::assert-equal b 5)
+(test::assert-equal \"opt-three\" (select-option 3))
+(test::assert-equal nil (select-option 4))
+(test::assert-equal \"opt-one\" (select-option-def 1))
+(test::assert-equal \"opt-two\" (select-option-def 2))
+(test::assert-equal \"opt-three\" (select-option-def 3))
+(test::assert-equal \"default\" (select-option-def 4))
 %#
 (defmacro cond
   (& branches)
@@ -593,9 +593,9 @@ and run some form, if-true, if provided-condition evaluates to true.
 Section: conditional
 
 Example:
-(assert-true (when #t #t))
-(assert-false (when #t nil))
-(assert-false (when nil nil))
+(test::assert-true (when #t #t))
+(test::assert-false (when #t nil))
+(test::assert-false (when nil nil))
 %#
 
 (defmacro when
@@ -608,124 +608,6 @@ Does nothing for now, namespaces aren't yet implemented.
 Section: core
 %#
 (defmacro ns-import (val) nil)
-
-#%
-Asserts the two values are identical.
-
-Section: test
-%#
-(defmacro assert-equal (expected-val right-val & body)
-    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
-        (if (= expected-val right-val)
-            #t
-            (let (ev (type expected-val)
-                  rv (type right-val)
-                  assert-err (mk-err :assert (str "Expected: " expected-val " " ev ", Got: " right-val " " rv "." ~@body)))
-                (do
-                    (prn assert-err)
-                    (err assert-err))))))
-
-#%
-Asserts the two values are identical.
-
-Section: test
-%#
-(defmacro test::assert-equal (& body) `(assert-equal ~@body))
-
-#%
-Asserts the two values are not identical.
-
-Section: test
-%#
-(defmacro assert-not-equal (expected-val right-val & body)
-    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
-        (if (not (= expected-val right-val))
-            #t
-            (let (ev (type expected-val)
-                  rv (type right-val)
-                  assert-err (mk-err :assert (str "Did not expect: " expected-val " " ev ", but got a matching: " right-val " " rv "." ~@body)))
-                (do
-                    (prn assert-err)
-                    (err assert-err))))))
-
-#%
-Asserts the two values are not identical.
-
-Section: test
-%#
-(defmacro test::assert-not-equal (& body) `(assert-not-equal ~@body))
-
-#%
-Asserts the value is true.
-
-Section: test
-%#
-(defmacro assert-true (val & body) `(assert-equal #t ~val ~@body))
-
-#%
-Asserts the value is true.
-
-Section: test
-%#
-(defmacro test::assert-true (& body) `(assert-true ~@body))
-
-#%
-Asserts the value is false
-
-Section: test
-%#
-(defmacro assert-false (val & body) `(assert-equal #f ~val ~@body))
-
-#%
-Asserts the value is false
-
-Section: test
-%#
-(defmacro test::assert-false (& body) `(assert-false ~@body))
-
-#%
-Asserts the value is an error
-
-Section: test
-%#
-(defmacro assert-error (val & body)
-    `(let (val (get-error ~val))
-        (if (err? val)
-            #t
-            (let (assert-err (mk-err :assert (str "Expected error got: " val "." ~@body)))
-                (do
-                    (prn assert-err)
-                    (err assert-err))))))
-
-#%
-Asserts the value is an error
-
-Section: test
-%#
-(defmacro test::assert-error (& body) `(assert-error ~@body))
-
-#%
-Test asserts an error is thrown with a given key and message.
-
-Section: test
-
-Example:
-(test::assert-error-msg (err "error thrown") :error "error thrown")
-%#
-(defmacro assert-error-msg (form key msg)
-    `((fn (ret) (test::assert-true (and (err? ret) (= ~key (car ret)) (= ~msg (cdr ret)))
-         (str ". Expected \n" ~key ", [" ~msg "]\n => Test returned:\n" (car ret) ", [" (cdr ret) "]")))
-        (get-error ~form)))
-
-#%
-Test asserts an error is thrown with a given key and message.
-
-Section: test
-
-Example:
-(test::assert-error-msg (err \"error thrown\") :error \"error thrown\")
-%#
-(defmacro test::assert-error-msg (& body) `(assert-error-msg ~@body))
 
 #%
 Usage: (with-temp-file (fn (x) (println "given temp file:" x)) ["optional-prefix" "optional-suffix" length])
@@ -829,7 +711,7 @@ Section: core
 
 Example:
 
-(assert-equal 0 (identity 0))
+(test::assert-equal 0 (identity 0))
 %#
 (defn identity (x) x)
 
@@ -841,10 +723,10 @@ Test if two values are not equal using `=`
 Section: core
 
 Example:
-(assert-true (not= 0 1))
-(assert-true (not= 1 1.0))
-(assert-false (not= 2 2))
-(assert-false (not= 0.0 -0.0))
+(test::assert-true (not= 0 1))
+(test::assert-true (not= 1 1.0))
+(test::assert-false (not= 2 2))
+(test::assert-false (not= 0.0 -0.0))
 %#
 (defmacro not= (expected-val right-val)
     `(not (= ~expected-val ~right-val))
@@ -858,10 +740,10 @@ Test if two values are not numerically equal using `==`
 Section: core
 
 Example:
-(assert-true (not== 0 1))
-(assert-false (not== 1 1.0))
-(assert-false (not== 0.0 -0.0))
-(assert-false (not== 2 2))
+(test::assert-true (not== 0 1))
+(test::assert-false (not== 1 1.0))
+(test::assert-false (not== 0.0 -0.0))
+(test::assert-false (not== 2 2))
 %#
 (defmacro not== (expected-val right-val)
     `(not (== ~expected-val ~right-val))
@@ -918,3 +800,4 @@ Example:
        `(nsubstitute! (to-list ~lst) ~old-item ~new-item ~@mods))
 
 (load "iterator.slosh")
+(load "test.slosh")

--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -181,9 +181,9 @@ Example:
 (test-mac test-mac-x)
 (test::assert-equal 15 test-mac-x)
 %#
-(def defmacro
+(comp-time (def defmacro
   (macro (name args & body)
-      `(def ~name (macro ~args ~@body))))
+      `(comp-time (def ~name (macro ~args ~@body))nil))) nil)
 
 #%
 Usage: (get-error exp0 ... expN) -> pair
@@ -601,13 +601,6 @@ Example:
 (defmacro when
     (provided-condition if-true)
     `(if ~provided-condition ~if-true))
-
-#%
-Does nothing for now, namespaces aren't yet implemented.
-
-Section: core
-%#
-(defmacro ns-import (val) nil)
 
 #%
 Usage: (with-temp-file (fn (x) (println "given temp file:" x)) ["optional-prefix" "optional-suffix" length])

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -1,4 +1,4 @@
-(ns iter)
+(with-ns iter
 
 #%
 Helper to create an iterator.  Will make sure it has the correct
@@ -333,7 +333,7 @@ Iterator that applies a lambda to each element to determine if is returned- is l
 Section: iterator
 
 Example:
-(let (test-iter (filter (vec-iter [1 2 3]) (fn (x) (not (= x 2)))))
+(let (test-iter (iter::filter (iter::vec-iter [1 2 3]) (fn (x) (not (= x 2)))))
     (test::assert-equal 1 (test-iter))
     (test::assert-equal 3 (test-iter))
     (test::assert-equal :*iter-empty* (test-iter)))
@@ -357,12 +357,12 @@ Section: iterator
 Example:
 
 (import iter)
-(test::assert-true (= 15 (reduce (vec-iter [1 2 3 4 5]) 0 +)))
-(test::assert-true (= 16 (reduce (vec-iter [1 2 3 4 5]) 1 +)))
-(test::assert-true (= \"one hoopy frood\" (reduce (vec-iter ["one " "hoopy " "frood"]) "" str)))
+(test::assert-true (= 15 (iter::reduce (iter::vec-iter [1 2 3 4 5]) 0 +)))
+(test::assert-true (= 16 (iter::reduce (iter::vec-iter [1 2 3 4 5]) 1 +)))
+(test::assert-true (= \"one hoopy frood\" (iter::reduce (iter::vec-iter ["one " "hoopy " "frood"]) "" str)))
 %#
 (defn reduce (iter acc reducing-fn)
     ; Use apply so we can seamlessly handle compiled forms (like +, -, etc).
     ; Currently they won't work without apply if passed in as the reducing-fn.
     (for val in iter (set! acc (apply reducing-fn acc val nil)))
-    acc)
+    acc))

--- a/lisp/iterator.slosh
+++ b/lisp/iterator.slosh
@@ -1,3 +1,5 @@
+(ns iter)
+
 #%
 Helper to create an iterator.  Will make sure it has the correct
 property set.
@@ -17,13 +19,14 @@ Iterator that wraps a vector.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-vec-iter (vec-iter [1 2 3]))
-    (assert-equal 1 (test-vec-iter))
-    (assert-equal 2 (test-vec-iter))
-    (assert-equal 3 (test-vec-iter))
-    (assert-equal :*iter-empty* (test-vec-iter))
+    (test::assert-equal 1 (test-vec-iter))
+    (test::assert-equal 2 (test-vec-iter))
+    (test::assert-equal 3 (test-vec-iter))
+    (test::assert-equal :*iter-empty* (test-vec-iter))
     (set! test-vec-iter (vec-iter (vec)))
-    (assert-equal :*iter-empty* (test-vec-iter)))
+    (test::assert-equal :*iter-empty* (test-vec-iter)))
 %#
 (defn vec-iter (v)
     (let (idx 0, vlen (len v))
@@ -35,13 +38,14 @@ Iterator produces a vector in reverse.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-vec-iter (vec-iter-rev [1 2 3]))
-    (assert-equal 3 (test-vec-iter))
-    (assert-equal 2 (test-vec-iter))
-    (assert-equal 1 (test-vec-iter))
-    (assert-equal :*iter-empty* (test-vec-iter))
+    (test::assert-equal 3 (test-vec-iter))
+    (test::assert-equal 2 (test-vec-iter))
+    (test::assert-equal 1 (test-vec-iter))
+    (test::assert-equal :*iter-empty* (test-vec-iter))
     (set! test-vec-iter (vec-iter-rev (vec)))
-    (assert-equal :*iter-empty* (test-vec-iter)))
+    (test::assert-equal :*iter-empty* (test-vec-iter)))
 %#
 (defn vec-iter-rev (v)
     (let (idx (len v))
@@ -55,15 +59,16 @@ produce the same items).
 Section: iterator
 
 Example:
+(import iter)
 (let ([fwd-iter, rev-iter] (vec-iter-pair [1 2 3]))
-    (assert-equal 1 (fwd-iter))
-    (assert-equal 3 (rev-iter))
-    (assert-equal 2 (fwd-iter))
-    (assert-equal :*iter-empty* (rev-iter))
-    (assert-equal :*iter-empty* (fwd-iter)))
+    (test::assert-equal 1 (fwd-iter))
+    (test::assert-equal 3 (rev-iter))
+    (test::assert-equal 2 (fwd-iter))
+    (test::assert-equal :*iter-empty* (rev-iter))
+    (test::assert-equal :*iter-empty* (fwd-iter)))
 (let ([fwd-iter, rev-iter] (vec-iter-pair (vec)))
-    (assert-equal :*iter-empty* (fwd-iter))
-    (assert-equal :*iter-empty* (rev-iter)))
+    (test::assert-equal :*iter-empty* (fwd-iter))
+    (test::assert-equal :*iter-empty* (rev-iter)))
 %#
 (defn vec-iter-pair (v)
     (let (fidx 0, bidx (len v))
@@ -77,13 +82,14 @@ Iterator that wraps a list.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-list-iter (list-iter '(1 2 3)))
-    (assert-equal 1 (test-list-iter))
-    (assert-equal 2 (test-list-iter))
-    (assert-equal 3 (test-list-iter))
-    (assert-equal :*iter-empty* (test-list-iter))
+    (test::assert-equal 1 (test-list-iter))
+    (test::assert-equal 2 (test-list-iter))
+    (test::assert-equal 3 (test-list-iter))
+    (test::assert-equal :*iter-empty* (test-list-iter))
     (set! test-list-iter (list-iter '()))
-    (assert-equal :*iter-empty* (test-list-iter)))
+    (test::assert-equal :*iter-empty* (test-list-iter)))
 %#
 (defn list-iter (l)
     (mk-iter (if l (let (val (car l)) (set! l (cdr l)) val) :*iter-empty*)))
@@ -95,6 +101,7 @@ trailing newline).
 Section: iterator
 
 Example:
+(import iter)
 (with-temp-file (fn (file-name)
     (let (tst-file (fopen file-name :create :truncate))
         (defer (fclose tst-file))
@@ -104,11 +111,11 @@ Example:
         (fpr tst-file "line 4"))
     (let (tst-file (fopen file-name), test-iter (file-iter tst-file))
         (defer (fclose tst-file))
-        (assert-equal "line 1\\n" (test-iter))
-        (assert-equal "line 2\\n" (test-iter))
-        (assert-equal "line 3\\n" (test-iter))
-        (assert-equal "line 4" (test-iter))
-        (assert-equal :*iter-empty* (test-iter)))))
+        (test::assert-equal "line 1\\n" (test-iter))
+        (test::assert-equal "line 2\\n" (test-iter))
+        (test::assert-equal "line 3\\n" (test-iter))
+        (test::assert-equal "line 4" (test-iter))
+        (test::assert-equal :*iter-empty* (test-iter)))))
 %#
 (defn file-iter (f)
     (mk-iter (let (line (read-line f))(if line line :*iter-empty*))))
@@ -119,11 +126,12 @@ Iterator that wraps a string.  Each element is the next character.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-string-iter (string-iter "123"))
-    (assert-equal \\1 (test-string-iter))
-    (assert-equal \\2 (test-string-iter))
-    (assert-equal \\3 (test-string-iter))
-    (assert-equal :*iter-empty* (test-string-iter)))
+    (test::assert-equal \\1 (test-string-iter))
+    (test::assert-equal \\2 (test-string-iter))
+    (test::assert-equal \\3 (test-string-iter))
+    (test::assert-equal :*iter-empty* (test-string-iter)))
 %#
 (defn string-iter (s)
     (let (idx 0, slen (len s))
@@ -135,8 +143,9 @@ Return true if thing is an iterator, false otherwise.
 Section: iterator
 
 Example:
-(assert-true (iter? (list-iter '(1 2 3))))
-(assert-false (iter? '(1 2 3)))
+(import iter)
+(test::assert-true (iter? (list-iter '(1 2 3))))
+(test::assert-false (iter? '(1 2 3)))
 %#
 (defn iter? (test)
     (if (get-prop test :is-iter) #t #f))
@@ -147,12 +156,13 @@ Iterator that wraps and returns a single object once.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-iter (once-iter 3))
-    (assert-equal 3 (test-iter))
-    (assert-equal :*iter-empty* (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal :*iter-empty* (test-iter))
     (set! test-iter (once-iter "iter"))
-    (assert-equal "iter" (test-iter))
-    (assert-equal :*iter-empty* (test-iter)))
+    (test::assert-equal "iter" (test-iter))
+    (test::assert-equal :*iter-empty* (test-iter)))
 %#
 (defn once-iter (i)
     (mk-iter (let (val i) (set! i :*iter-empty*) val)))
@@ -163,18 +173,19 @@ Iterator that wraps and returns a single object on each call.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-iter (repeat-iter 3))
-    (assert-equal 3 (test-iter))
-    (assert-equal 3 (test-iter))
-    (assert-equal 3 (test-iter))
-    (assert-equal 3 (test-iter))
-    (assert-equal 3 (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal 3 (test-iter))
     (set! test-iter (repeat-iter "iter"))
-    (assert-equal "iter" (test-iter))
-    (assert-equal "iter" (test-iter))
-    (assert-equal "iter" (test-iter))
-    (assert-equal "iter" (test-iter))
-    (assert-equal "iter" (test-iter)))
+    (test::assert-equal "iter" (test-iter))
+    (test::assert-equal "iter" (test-iter))
+    (test::assert-equal "iter" (test-iter))
+    (test::assert-equal "iter" (test-iter))
+    (test::assert-equal "iter" (test-iter)))
 %#
 (defn repeat-iter (i)
     (mk-iter i))
@@ -185,10 +196,11 @@ Return thing as an iterator if possible (if it is an iterator just return thing)
 Section: iterator
 
 Example:
-(assert-true (iter? (iter '(1 2 3))))
-(assert-true (iter? (iter [1 2 3])))
-(assert-true (iter? (iter "abc")))
-(assert-true (iter? (iter (iter '(1 2 3)))))
+(import iter)
+(test::assert-true (iter? (iter '(1 2 3))))
+(test::assert-true (iter? (iter [1 2 3])))
+(test::assert-true (iter? (iter "abc")))
+(test::assert-true (iter? (iter (iter '(1 2 3)))))
 %#
 (defn iter (thing)
   (if (iter? thing)
@@ -210,12 +222,13 @@ If not possible then wrap thing in a once iter and return that.
 Section: iterator
 
 Example:
-(assert-true (iter? (iter-or-single '(1 2 3))))
-(assert-true (iter? (iter-or-single [1 2 3])))
-(assert-true (iter? (iter-or-single "abc")))
-(assert-true (iter? (iter-or-single (iter '(1 2 3)))))
-(assert-true (iter? (iter-or-single 1)))
-(assert-true (iter? (iter-or-single \\A)))
+(import iter)
+(test::assert-true (iter? (iter-or-single '(1 2 3))))
+(test::assert-true (iter? (iter-or-single [1 2 3])))
+(test::assert-true (iter? (iter-or-single "abc")))
+(test::assert-true (iter? (iter-or-single (iter '(1 2 3)))))
+(test::assert-true (iter? (iter-or-single 1)))
+(test::assert-true (iter? (iter-or-single \\A)))
 %#
 (defn iter-or-single (thing)
   (if (iter? thing)
@@ -236,11 +249,12 @@ Iterator that generates numbers within a range.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-iter (range 3 6))
-    (assert-equal 3 (test-iter))
-    (assert-equal 4 (test-iter))
-    (assert-equal 5 (test-iter))
-    (assert-equal :*iter-empty* (test-iter)))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal 4 (test-iter))
+    (test::assert-equal 5 (test-iter))
+    (test::assert-equal :*iter-empty* (test-iter)))
 %#
 (defn range (start end)
     (mk-iter (if (< start end) (let (tmp start) (inc! start) tmp) :*iter-empty*)))
@@ -253,16 +267,17 @@ index.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-iter (enumerate (vec-iter [:a :b :c])))
-    (let ([i v] (test-iter)) (assert-equal 0 i) (assert-equal :a v))
-    (let ([i v] (test-iter)) (assert-equal 1 i) (assert-equal :b v))
-    (let ([i v] (test-iter)) (assert-equal 2 i) (assert-equal :c v))
-    (assert-equal :*iter-empty* (test-iter)))
+    (let ([i v] (test-iter)) (test::assert-equal 0 i) (test::assert-equal :a v))
+    (let ([i v] (test-iter)) (test::assert-equal 1 i) (test::assert-equal :b v))
+    (let ([i v] (test-iter)) (test::assert-equal 2 i) (test::assert-equal :c v))
+    (test::assert-equal :*iter-empty* (test-iter)))
 (let (test-iter (enumerate (vec-iter [:a :b :c]) 5))
-    (let ([i v] (test-iter)) (assert-equal 5 i) (assert-equal :a v))
-    (let ([i v] (test-iter)) (assert-equal 6 i) (assert-equal :b v))
-    (let ([i v] (test-iter)) (assert-equal 7 i) (assert-equal :c v))
-    (assert-equal :*iter-empty* (test-iter)))
+    (let ([i v] (test-iter)) (test::assert-equal 5 i) (test::assert-equal :a v))
+    (let ([i v] (test-iter)) (test::assert-equal 6 i) (test::assert-equal :b v))
+    (let ([i v] (test-iter)) (test::assert-equal 7 i) (test::assert-equal :c v))
+    (test::assert-equal :*iter-empty* (test-iter)))
 %#
 (defn enumerate (iter % start := 0)
     (let (idx start)
@@ -280,11 +295,12 @@ in body. Body is evaluated a number of times equal to the items in the iterator.
 Section: iterator
 
 Example:
+(import iter)
 (let (i 0)
     (for x in (range 0 11) (set! i (+ 1 i)))
-    (assert-equal 11 i))
+    (test::assert-equal 11 i))
 (let (v [:a :b :c], iter (enumerate (vec-iter v)))
-    (for [idx, val] in iter (assert-equal v.~idx val)))
+    (for [idx, val] in iter (test::assert-equal v.~idx val)))
 %#
 (defmacro for (bind in items & body)
     (if (not (= in 'in)) (err "Invalid for: (for [i] in [iterator] (body))"))
@@ -300,11 +316,12 @@ Iterator that applies a lambda to each element of another iterator- is lazy.
 Section: iterator
 
 Example:
+(import iter)
 (let (test-map-iter (map (list-iter '(1 2 3)) (fn (x) (* x 2))))
-    (assert-equal 2 (test-map-iter))
-    (assert-equal 4 (test-map-iter))
-    (assert-equal 6 (test-map-iter))
-    (assert-equal :*iter-empty* (test-map-iter)))
+    (test::assert-equal 2 (test-map-iter))
+    (test::assert-equal 4 (test-map-iter))
+    (test::assert-equal 6 (test-map-iter))
+    (test::assert-equal :*iter-empty* (test-map-iter)))
 %#
 (defn map (i lambda)
     (mk-iter (let (val (i)) (if (identical? val :*iter-empty*) :*iter-empty* (lambda val)))))
@@ -317,9 +334,9 @@ Section: iterator
 
 Example:
 (let (test-iter (filter (vec-iter [1 2 3]) (fn (x) (not (= x 2)))))
-    (assert-equal 1 (test-iter))
-    (assert-equal 3 (test-iter))
-    (assert-equal :*iter-empty* (test-iter)))
+    (test::assert-equal 1 (test-iter))
+    (test::assert-equal 3 (test-iter))
+    (test::assert-equal :*iter-empty* (test-iter)))
 %#
 (defn filter (iter lambda)
     (mk-iter (let (val (iter)) (while (and (not (identical? val :*iter-empty*))(not (lambda val))) (set! val (iter))) val)))
@@ -339,9 +356,10 @@ Section: iterator
 
 Example:
 
-(assert-true (= 15 (reduce (vec-iter [1 2 3 4 5]) 0 +)))
-(assert-true (= 16 (reduce (vec-iter [1 2 3 4 5]) 1 +)))
-(assert-true (= \"one hoopy frood\" (reduce (vec-iter ["one " "hoopy " "frood"]) "" str)))
+(import iter)
+(test::assert-true (= 15 (reduce (vec-iter [1 2 3 4 5]) 0 +)))
+(test::assert-true (= 16 (reduce (vec-iter [1 2 3 4 5]) 1 +)))
+(test::assert-true (= \"one hoopy frood\" (reduce (vec-iter ["one " "hoopy " "frood"]) "" str)))
 %#
 (defn reduce (iter acc reducing-fn)
     ; Use apply so we can seamlessly handle compiled forms (like +, -, etc).

--- a/lisp/sh-color.slosh
+++ b/lisp/sh-color.slosh
@@ -78,8 +78,8 @@ True if the supplied command is a system command.
 Section: shell
 
 Example:
-(assert-true (sys-command? "ls"))
-(assert-false (sys-command? "rst-not-a-comand-strsnt"))
+(test::assert-true (sys-command? "ls"))
+(test::assert-false (sys-command? "rst-not-a-comand-strsnt"))
 %#
 (defn sys-command? (com)
     (if (or (str-empty? com)(identical? com.0 \/)(identical? com.0 \.))

--- a/lisp/test.slosh
+++ b/lisp/test.slosh
@@ -1,4 +1,4 @@
-(ns test)
+(with-ns test
 
 #%
 Asserts the two values are identical.
@@ -71,5 +71,5 @@ Example:
 (defmacro assert-error-msg (form key msg)
     `((fn (ret) (test::assert-true (and (err? ret) (= ~key (car ret)) (= ~msg (cdr ret)))
          (str ". Expected \n" ~key ", [" ~msg "]\n => Test returned:\n" (car ret) ", [" (cdr ret) "]")))
-        (get-error ~form)))
+        (get-error ~form))))
 

--- a/lisp/test.slosh
+++ b/lisp/test.slosh
@@ -1,0 +1,75 @@
+(ns test)
+
+#%
+Asserts the two values are identical.
+
+Section: test
+%#
+(defmacro assert-equal (expected-val right-val & body)
+    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
+        (if (= expected-val right-val)
+            #t
+            (let (ev (type expected-val)
+                  rv (type right-val)
+                  assert-err (mk-err :assert (str "Expected: " expected-val " " ev ", Got: " right-val " " rv "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
+
+#%
+Asserts the two values are not identical.
+
+Section: test
+%#
+(defmacro assert-not-equal (expected-val right-val & body)
+    `(let (expected-val ~expected-val, right-val ~right-val) ; make sure to eval expressions only once.
+        (if (not (= expected-val right-val))
+            #t
+            (let (ev (type expected-val)
+                  rv (type right-val)
+                  assert-err (mk-err :assert (str "Did not expect: " expected-val " " ev ", but got a matching: " right-val " " rv "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
+
+#%
+Asserts the value is true.
+
+Section: test
+%#
+(defmacro assert-true (val & body) `(test::assert-equal #t ~val ~@body))
+
+#%
+Asserts the value is false
+
+Section: test
+%#
+(defmacro assert-false (val & body) `(test::assert-equal #f ~val ~@body))
+
+#%
+Asserts the value is an error
+
+Section: test
+%#
+(defmacro assert-error (val & body)
+    `(let (val (get-error ~val))
+        (if (err? val)
+            #t
+            (let (assert-err (mk-err :assert (str "Expected error got: " val "." ~@body)))
+                (do
+                    (prn assert-err)
+                    (err assert-err))))))
+
+#%
+Test asserts an error is thrown with a given key and message.
+
+Section: test
+
+Example:
+(test::assert-error-msg (err "error thrown") :error "error thrown")
+%#
+(defmacro assert-error-msg (form key msg)
+    `((fn (ret) (test::assert-true (and (err? ret) (= ~key (car ret)) (= ~msg (cdr ret)))
+         (str ". Expected \n" ~key ", [" ~msg "]\n => Test returned:\n" (car ret) ", [" (cdr ret) "]")))
+        (get-error ~form)))
+

--- a/slosh/bench_utils/benches/float-bench.slosh
+++ b/slosh/bench_utils/benches/float-bench.slosh
@@ -1,5 +1,7 @@
 #!/usr/bin/env slosh
 
+(load "core.slosh")
+
 (def eval-pol (fn (n x)
   (let (su 0.0
         mu 10.0

--- a/slosh/bench_utils/benches/float-bench.slosh
+++ b/slosh/bench_utils/benches/float-bench.slosh
@@ -1,7 +1,5 @@
 #!/usr/bin/env slosh
 
-(load "core.slosh")
-
 (def eval-pol (fn (n x)
   (let (su 0.0
         mu 10.0

--- a/slosh/bench_utils/benches/vec-search-bench.slosh
+++ b/slosh/bench_utils/benches/vec-search-bench.slosh
@@ -1,6 +1,5 @@
 #!/usr/bin/env slosh
 
-(load "core.slosh")
 ;; benchmark on lists?
 
 (defn build-vec (fst-elem limit)
@@ -28,7 +27,7 @@
 (defn is-limit (x limit) (= limit x))
 
 (defn run-recursive (limit)
-    (assert-true (naive-recursive-find is-limit (build-vec limit limit) limit)))
+    (test::assert-true (naive-recursive-find is-limit (build-vec limit limit) limit)))
 
 (defn run-continuation (limit)
-    (assert-true (naive-continuation-find is-limit (build-vec limit limit) limit)))
+    (test::assert-true (naive-continuation-find is-limit (build-vec limit limit) limit)))

--- a/slosh/bench_utils/benches/vec-search-bench.slosh
+++ b/slosh/bench_utils/benches/vec-search-bench.slosh
@@ -1,5 +1,6 @@
 #!/usr/bin/env slosh
 
+(load "core.slosh")
 ;; benchmark on lists?
 
 (defn build-vec (fst-elem limit)

--- a/slosh/tests/equality.slosh
+++ b/slosh/tests/equality.slosh
@@ -1,5 +1,7 @@
 #!/usr/bin/env slosh
 
+(import test)
+
 (assert-true (= 1 1))
 (assert-false (= 2 2.0))
 (assert-true (not= 2 2.0))

--- a/slosh_lib/src/lib.rs
+++ b/slosh_lib/src/lib.rs
@@ -364,6 +364,8 @@ pub fn set_builtins(env: &mut SloshVm) {
     env.set_named_global("*int-bits*", (INT_BITS as i64).into());
     env.set_named_global("*int-max*", INT_MAX.into());
     env.set_named_global("*int-min*", INT_MIN.into());
+    let i = env.intern("ROOT");
+    env.set_named_global("*ns*", Value::Symbol(i));
 }
 
 pub fn new_slosh_vm_with_builtins() -> SloshVm {

--- a/slosh_lib/src/liner_rules.rs
+++ b/slosh_lib/src/liner_rules.rs
@@ -10,7 +10,7 @@ fn check_balanced_delimiters_lisp(input: &str) -> bool {
     let mut braces: i32 = 0;
     let mut double_quote = false;
     let mut escape = false;
-    // TODO, should probably handle multiline comments #|...|#
+    // TODO, should probably handle multiline comments #|...|#, docstrings #!...!# and string literals #"X...X"
     for ch in input.chars() {
         if escape {
             escape = false;

--- a/slosh_lib/src/liner_rules.rs
+++ b/slosh_lib/src/liner_rules.rs
@@ -20,7 +20,7 @@ fn check_balanced_delimiters_lisp(input: &str) -> bool {
             double_quote = false;
             continue;
         }
-        if double_quote {
+        if double_quote && ch != '\\' {
             continue;
         }
         match ch {

--- a/slosh_test/run-tests.slosh
+++ b/slosh_test/run-tests.slosh
@@ -1,7 +1,5 @@
 #!/usr/bin/env slosh_test
 
-(load "core.slosh")
-
 (let (globals (get-globals-sorted)
       globals-len (len globals)
       i 0


### PR DESCRIPTION
See docs for load, run-script, ns, with-ns, import.

Add namespace support.  It is really just bookkeeping in the compiler but there were some interesting load issues.  The load special form now compiles the file at compile time (run-script works 100% at runtime like old load).

Also added a comp-time special form that runs arbitrary code at compile time (similar to macros).

Macros are installed fully at compile time now (using cost-time), this fixes a chicken egg macros issue when using them as you define them.