### PR TITLE
Remove slosh history line count from default init.slosh

### DIFF
--- a/init.slosh
+++ b/init.slosh
@@ -68,6 +68,6 @@
 (prn "		We don't have to be mean because,")
 (prn "		remember, no matter where you go,")
 (prn "		there you are.")
-(prn (str "			- Buckaroo Banzai (" (str-trim $(cat ~/.local/share/sl-sh/history | grep -v "<ctx>" | wc -l)) ")"))
+(prn "			- Buckaroo Banzai")
 
 ;; }}}


### PR DESCRIPTION
init.slosh has us printing the result of this statement `(" (str-trim $sh(cat ~/.local/share/sl-sh/history | grep -v "<ctx>" | wc -l)) ")")`

but it gives me `Reader error: Unquote outside of a back-quote` so we should remove or fix