### PR TITLE
Update readme installation instructions for mac [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ cargo run -p slosh
 - install binary
 
 ```
-sudo install -D -m 755 target/release/slosh /usr/local/bin/
+mkdir -p /usr/local/bin
+sudo install -m 755 target/release/slosh /usr/local/bin/
 ```
 
 - add slosh to /etc/shells and change login shell to slosh
@@ -73,6 +74,11 @@ sudo install -D -m 755 target/release/slosh /usr/local/bin/
 echo /usr/local/bin/slosh | sudo tee -a /etc/shells
 chsh -s /usr/local/bin/slosh
 ```
+### 4. (Optional) Configure slosh
+The slosh configuration file lives at ~/.config/slosh/init.slosh. <br>
+If you run slosh and the file does not exist, a default one will be created for you. <br>
+Review your existing shell configuration files like ~/.bashrc and ~/.bash_profile and manually translate them to slosh syntax and add to your init.slosh file <br>
+For example, `export JAVA_HOME="/usr/local/opt/openjdk@11/bin/java"` becomes `(sh "export JAVA_HOME='/usr/local/opt/openjdk@11/bin/java'")`
 
 ## Compiler
 

--- a/init.slosh
+++ b/init.slosh
@@ -33,7 +33,7 @@
 (sh "alias vi=nvim")
 (sh "alias vim=nvim")
 
-(sh "export PATH=/bin:/usr/local/bin:~/bin:~/.cargo/bin")
+(sh "export PATH=/bin:/usr/bin:/usr/local/bin:~/bin:~/.cargo/bin")
 
 (sh "export LC_ALL=en_US.UTF-8")
 


### PR DESCRIPTION
Addressing issue #121 makes these changes to the readme

- recommending that users performing a new installation should migrate their existing rc files' contents into their init.slosh file
- changing the `install` command from using the `-D` flag which is not supported on mac to doing the more universal `mkdir -p`
- adding /usr/bin to the PATH