### PR TITLE
Fix Clippy issues from upgrading to Clippy 0.1.80

### DIFF
--- a/bridge_macros/src/lib.rs
+++ b/bridge_macros/src/lib.rs
@@ -186,7 +186,7 @@ fn get_generic_argument_from_type_path(
     type_path: &TypePath,
 ) -> Option<(&GenericArgument, &TypePath)> {
     if type_path.path.segments.len() == 1 {
-        for path_segment in &type_path.path.segments.iter().next_back() {
+        if let Some(path_segment) = &type_path.path.segments.iter().next_back() {
             if let PathArguments::AngleBracketed(args) = &path_segment.arguments {
                 if let Some(ty) = args.args.iter().next_back() {
                     return Some((ty, type_path));
@@ -1552,10 +1552,10 @@ fn parse_attributes(
 /// intern_<original_fn_name>
 /// parse_<original_fn_name>
 /// - intern_ is the simplest function, it is generated to be called within sl-sh to avoid writing
-/// boilerplate code to submit a function symbol and the associated code to the runtime.
+///   boilerplate code to submit a function symbol and the associated code to the runtime.
 /// - parse_ has the same function signature as all rust native functions, it takes the environment
-/// and a list of args. It evals those arguments at runtime and converts them to rust types
-/// they can be consumed by the target rust function.
+///   and a list of args. It evals those arguments at runtime and converts them to rust types
+///   they can be consumed by the target rust function.
 fn generate_sl_sh_fn(
     original_item_fn: &ItemFn,
     attr_args: AttributeArgs,

--- a/slosh_lib/src/lib.rs
+++ b/slosh_lib/src/lib.rs
@@ -490,7 +490,7 @@ fn run_shell_tty() -> i32 {
     //Box::new(keymap::Emacs::new())
     con.set_keymap(Box::new(vi));
 
-    if let Err(e) = con.history.set_file_name_and_load_history(&history_file()) {
+    if let Err(e) = con.history.set_file_name_and_load_history(history_file()) {
         println!("Error loading history: {e}");
     }
     shell::run::setup_shell_tty(STDIN_FILENO);

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,12 +4,6 @@ version = "0.1.0"
 authors = ["Steven Stanfield <stanfield@scarecrowtech.com>"]
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-gc = []
-nohelmet = []
-
 [dependencies]
 unicode-segmentation = "1.10.1"
 bridge_types = { workspace = true }

--- a/vm/src/fxhasher.rs
+++ b/vm/src/fxhasher.rs
@@ -23,7 +23,6 @@
 //! # fn main() { }
 //! ```
 
-
 use core::convert::TryInto;
 use core::default::Default;
 use core::hash::BuildHasherDefault;

--- a/vm/src/fxhasher.rs
+++ b/vm/src/fxhasher.rs
@@ -23,8 +23,6 @@
 //! # fn main() { }
 //! ```
 
-#[cfg(feature = "std")]
-extern crate std;
 
 use core::convert::TryInto;
 use core::default::Default;

--- a/vm/src/vm/macros.rs
+++ b/vm/src/vm/macros.rs
@@ -1,7 +1,9 @@
 #[macro_export]
 macro_rules! inc_ip {
     ($code_ip:expr) => {{
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe {
+            // SAFETY: `$code_ip` must be a valid pointer to at least 1 byte of memory.
             let r = *$code_ip;
             $code_ip = $code_ip.offset(1);
             r
@@ -33,7 +35,9 @@ macro_rules! decode_u8 {
 #[macro_export]
 macro_rules! decode_u16 {
     ($code:expr) => {{
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe {
+            // SAFETY: `$code` must be a valid pointer to at least 2 bytes of memory.
             let idx1 = *$code;
             let idx2 = *$code.offset(1);
             $code = $code.offset(2);
@@ -45,7 +49,9 @@ macro_rules! decode_u16 {
 #[macro_export]
 macro_rules! decode_u32 {
     ($code:expr) => {{
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe {
+            // SAFETY: `$code` must be a valid pointer to at least 4 bytes of memory.
             let idx1 = *$code;
             let idx2 = *$code.offset(1);
             let idx3 = *$code.offset(2);
@@ -74,7 +80,9 @@ macro_rules! decode2 {
             (decode_u16!($code), decode_u16!($code))
         } else {
             //(crate::inc_ip!($code) as u16, crate::inc_ip!($code) as u16)
+            #[allow(clippy::macro_metavars_in_unsafe)]
             unsafe {
+                // SAFETY: $code must be a valid pointer to at least 2 bytes of memory.
                 let r = (*$code as u16, *$code.offset(1) as u16);
                 $code = $code.offset(2);
                 r
@@ -89,7 +97,9 @@ macro_rules! decode3 {
         if $wide {
             (decode_u16!($code), decode_u16!($code), decode_u16!($code))
         } else {
+            #[allow(clippy::macro_metavars_in_unsafe)]
             unsafe {
+                // SAFETY: $code must be a valid pointer to at least 3 bytes of memory.
                 let r = (
                     *$code as u16,
                     *$code.offset(1) as u16,


### PR DESCRIPTION
apply clippy lint `for_loops_over_fallibles`
apply clippy lint `doc_lazy_continuation`
apply clippy lint `needless_borrows_for_generic_args `
ignore clippy lint `macro_metavars_in_unsafe`
fixed clippy lint `unexpected_cfgs` by removing code that would support a no_std build
remove unused feature options from vm