### PR TITLE
Added justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,35 @@
 default:
     @just --list --unsorted
 
-# For all the recipes in this file, don't echo the commands to the terminal
-set quiet
+# Run all the necessary tests: clippy, unit tests, and integration tests
+test:
+    sh scripts/check-clippy-version.sh
+    cargo fmt
+    cargo clippy
+    cargo test --workspace
+
+# Generate and open the slosh docs
+sloshdoc:
+    cd doc && ./mk-site.sh
+    open doc/book/index.html
+
+# Generate and open the rust docs
+rustdoc:
+    cargo doc --workspace --no-deps --open
+
+
+# The remaining commands in the project are less commonly used
+
+# These tests are a subset of 'cargo test --workspace'
+# It runs ./slosh_test/tests/slosh-tests.rs which loads /slosh_test/run-tests.slosh which loads up all the globals and executes the Example block of each docstring
+# Test docstring examples of slosh globals defined with add_builtin or add_special
+test-globals:
+    cargo test --package slosh_test --test slosh-tests run_slosh_tests -- --exact --nocapture
+
+# These tests are a subset of 'cargo test --workspace'
+# Test slosh tests defined in /slosh/tests/*.slosh
+test-lisp:
+    cargo test --package slosh --test lisp-scripts -- --nocapture
 
 # Run the most recently built slosh executable
 slosh:
@@ -27,24 +54,7 @@ slosh:
         cargo build && ./target/debug/slosh; \
     fi
 
-# Run all the necessary tests: clippy, unit tests, and integration tests
-test:
-    sh scripts/check-clippy-version.sh
-    cargo fmt
-    cargo clippy
-    cargo test --workspace
-
-# These tests are a subset of 'cargo test --workspace'
-# It runs ./slosh_test/tests/slosh-tests.rs which loads /slosh_test/run-tests.slosh which loads up all the globals and executes the Example block of each docstring
-# Test docstring examples of slosh globals defined with add_builtin or add_special
-test-slosh-globals:
-     cargo test --package slosh_test --test slosh-tests run_slosh_tests -- --exact --nocapture
-
-# These tests are a subset of 'cargo test --workspace'
-# Test slosh tests defined in /slosh/tests/*.slosh
-test-slosh-tests:
-    cargo test --package slosh --test lisp-scripts -- --nocapture
-
-# Use cspell to spellcheck the codebase
+# Using `npx` requires installing `npm` which comes with `nodejs` from https://nodejs.org/en/download/
+# Use javascript cspell tool to spellcheck the codebase
 spellcheck:
     npx cspell .

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,50 @@
+# Justfile
+# 'just' is a command runner, like a modern 'make'
+# Install instructions at https://github.com/casey/just?tab=readme-ov-file#installation
+# Usage is as simple as 'just test' to run all the tests we care about.
+
+# The default recipe that runs if you type 'just' with no arguments
+# List available commands
+default:
+    @just --list --unsorted
+
+# For all the recipes in this file, don't echo the commands to the terminal
+set quiet
+
+# Run the most recently built slosh executable
+slosh:
+    @if [ -f ./target/debug/slosh ] && [ -f ./target/release/slosh ]; then \
+        if [ ./target/debug/slosh -nt ./target/release/slosh ]; then \
+            ./target/debug/slosh; \
+        else \
+            ./target/release/slosh; \
+        fi; \
+    elif [ -f ./target/debug/slosh ]; then \
+        ./target/debug/slosh; \
+    elif [ -f ./target/release/slosh ]; then \
+        ./target/release/slosh; \
+    else \
+        cargo build && ./target/debug/slosh; \
+    fi
+
+# Run all the necessary tests: clippy, unit tests, and integration tests
+test:
+    sh scripts/check-clippy-version.sh
+    cargo fmt
+    cargo clippy
+    cargo test --workspace
+
+# These tests are a subset of 'cargo test --workspace'
+# It runs ./slosh_test/tests/slosh-tests.rs which loads /slosh_test/run-tests.slosh which loads up all the globals and executes the Example block of each docstring
+# Test docstring examples of slosh globals defined with add_builtin or add_special
+test-slosh-globals:
+     cargo test --package slosh_test --test slosh-tests run_slosh_tests -- --exact --nocapture
+
+# These tests are a subset of 'cargo test --workspace'
+# Test slosh tests defined in /slosh/tests/*.slosh
+test-slosh-tests:
+    cargo test --package slosh --test lisp-scripts -- --nocapture
+
+# Use cspell to spellcheck the codebase
+spellcheck:
+    npx cspell .

--- a/README.md
+++ b/README.md
@@ -221,3 +221,19 @@ All of this is covered in `doc/README.md`
 
 Must be compiled in lisp-test mode for appropriate documentation functions to be present (`cargo build --features lisp-test`).
 
+# Dev Notes
+## Development Tools
+### Just and the Justfile
+[Just](https://github.com/casey/just) is a command runner much like make, but with a simpler syntax.
+
+Optionally, you can [install Just](https://github.com/casey/just?tab=readme-ov-file#packages) and use it to help easily test or build slosh.
+
+You can also read the Justfile in the root directory to see the common commands that we use to test and build the project.
+
+<br>
+
+To verify you've installed Just, run `just` in the project root which should list all available commands.
+
+Now you can run `just test` instead of the verbose `sh scripts/check-clippy-version.sh && cargo fmt && cargo clippy && cargo test --workspace`.
+
+It's also possible to [set up shell completion scripts](https://github.com/casey/just?tab=readme-ov-file#shell-completion-scripts) which makes it quite quick to find the right command.

--- a/scripts/check-clippy-version.sh
+++ b/scripts/check-clippy-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# STEP 1. Extract the version of Clippy from the readme of GitHub's runner-images repository
+remoteVersion=$(curl -s https://raw.githubusercontent.com/actions/runner-images/main/images/ubuntu/Ubuntu2204-Readme.md | grep "Cargo clippy" | awk '{print $4}')
+
+# STEP 2. Extract the version of Clippy from the local installation
+localVersion=$(cargo clippy --version | awk '{print $2}')
+
+# STEP 3. Alert the user if they should update or not
+if [ "$remoteVersion" != "$localVersion" ]; then
+    echo "\033[31m⚠️  Outdated Clippy version (v$localVersion) is behind GitHub CI runner (v$remoteVersion). Consider \`rustup update\`\033[0m"
+    exit 1
+else
+    echo "\033[32m✓ Up-to-date Clippy version (v$localVersion)\033[0m"
+    exit 0
+fi


### PR DESCRIPTION
[Just](https://github.com/casey/just) is a popular command runner to replace `make`. I have struggled to remember and to type the exact wording of various tests so this allows me to type `just test` and cover all of my bases.  

Also note the script that checks the version of `cargo clippy` in the CI and compares it to your local `cargo clippy` version to remind you to update if necessary