### PR TITLE
chore: appease clippy 0.1.81

### DIFF
--- a/bridge_adapters/src/lisp_adapters.rs
+++ b/bridge_adapters/src/lisp_adapters.rs
@@ -134,7 +134,7 @@ where
 
 impl<'a, T> SlFromRef<'a, slvm::Value> for Vec<T>
 where
-    T: SlFromRef<'a, Value> + 'a + ?Sized,
+    T: SlFromRef<'a, Value> + 'a,
 {
     fn sl_from_ref(value: slvm::Value, vm: &'a SloshVm) -> VMResult<Self> {
         let mut res = vec![];


### PR DESCRIPTION
We just have one violation of Clippy's lint [needless_maybe_sized](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_maybe_sized) for 
```rust
// line 137 of lisp_adapters.rs
    T: SlFromRef<'a, Value> + 'a + ?Sized,
```
Since the type `T` must satisfy the `SlFromRef<'a, Value>` bound which is itself defined to be `Sized`

```rust
// line 167 of lisp_adapters.rs
pub trait SlFromRef<'a, T: BridgedType>
where
    Self: Sized,
{
    //...
}
```