### PR TITLE
fix: docs macro no longer double-printing usage string

### DIFF
--- a/lisp/core.slosh
+++ b/lisp/core.slosh
@@ -289,11 +289,11 @@ Section: core
 %#
 (defmacro doc (sym)
     (let (docs `(get-prop ~sym :doc-string)
-         has-usage (str-starts-with "Usage:" (str-trim (str docs))))
+         has-usage `(str-starts-with (str-trim (str ~docs)) "Usage:"))
         (do
-        (if has-usage
-          `(prn ~docs)
-          `(prn (str (usage ~sym) "\n\n" ~docs))))))
+        `(if ~has-usage
+          (prn ~docs)
+          (prn (str (usage ~sym) "\n\n" ~docs))))))
 
 #%
 Evaluate body a number of times equal to times' numerical value.


### PR DESCRIPTION
Problem 1: argument order was incorrect for `str-starts-with` so the result was always `false`.
Problem 2: some quoting and unquoting needed to be rearranged in order to get `has-usage` to actually be evaluated properly

Without this fix, you can issue a command like `(doc 'rem)` and see that the usage string is printed twice because the `doc` macro can't find an existing usage string and decides to try to add the usage string, doubling it.