### PR TITLE
WIP, initial shell redirects through lisp.

### DIFF
--- a/shell/src/run.rs
+++ b/shell/src/run.rs
@@ -96,7 +96,7 @@ pub fn run_job(run: &Run, jobs: &mut Jobs, force_background: bool) -> Result<i32
             let mut job = jobs.new_job();
             job.set_stealth(force_background);
             match run_pipe(&pipe[..], &mut job, jobs) {
-                Ok(background) => finish_run(background, job, jobs),
+                Ok(background) => finish_run(force_background || background, job, jobs),
                 Err(err) => {
                     // Make sure we restore the terminal...
                     jobs.restore_terminal();


### PR DESCRIPTION
Still figuring this out currently allows things like this (syntax will probably change):

(let ([out] (sh "ls" :>)) (iter::for l in (iter::iter out) (pr l)))

(let ([in, out] (sh :> "grep XX" :>)) (fprn in "XXsls")(fprn in "sls")(fprn in "dfdXX")(fclose in)(iter::for l in (iter::iter out)(pr l)))

(same as above but include a pipe between shell commands)
(let ([in, out] (sh :> "grep XX | cat -" :>)) (fprn in "XXsls")(fprn in "sls")(fprn in "dfdXX")(fclose in)(iter::for l in (iter::iter out)(pr l)))