### PR TITLE
proposed fix, having trouble using curly braces in doc comments

### DIFF
--- a/compiler/src/reader.rs
+++ b/compiler/src/reader.rs
@@ -524,7 +524,7 @@ impl<'vm> Reader<'vm> {
                 if self.end_string(&ch, doc_string)? {
                     break;
                 }
-                if ch == "{" && !docstring {
+                if ch == "{" && !doc_string {
                     if args.is_empty() {
                         args.push(Value::Symbol(self.vm.intern("str")));
                     }

--- a/compiler/src/reader.rs
+++ b/compiler/src/reader.rs
@@ -524,7 +524,7 @@ impl<'vm> Reader<'vm> {
                 if self.end_string(&ch, doc_string)? {
                     break;
                 }
-                if ch == "{" {
+                if ch == "{" && !docstring {
                     if args.is_empty() {
                         args.push(Value::Symbol(self.vm.intern("str")));
                     }


### PR DESCRIPTION
do we have string interpolation?

is that what i'm running into?

If we do (and I just broke it) the string interpolation needs to be backslash aware so we can still use curly braces in documentation comments right?