### PR TITLE
allow any user file to be safely loaded within context of user doc generation

### DIFF
--- a/bridge_macros/src/lib.rs
+++ b/bridge_macros/src/lib.rs
@@ -1430,18 +1430,6 @@ fn parse_src_function_arguments(
     takes_env: bool,
 ) -> MacroResult<Vec<Param>> {
     let mut parsed_args = vec![];
-    let len = if takes_env {
-        original_item_fn.sig.inputs.len() - 1
-    } else {
-        original_item_fn.sig.inputs.len()
-    };
-    let mut arg_names = vec![];
-    for i in 0..len {
-        let parse_name = "arg_".to_string() + &i.to_string();
-        let parse_name = Ident::new(&parse_name, Span::call_site());
-        arg_names.push(parse_name);
-    }
-
     let skip = usize::from(takes_env);
 
     for (i, fn_arg) in original_item_fn.sig.inputs.iter().enumerate().skip(skip) {
@@ -1547,7 +1535,7 @@ fn parse_attributes(
     Ok((fn_name, fn_name_ident, takes_env, inline, generics))
 }
 
-/// this function outputs all of the generated code, it is composed into two different functions:
+/// this function outputs all the generated code, it is composed into two different functions:
 /// intern_<original_fn_name>
 /// parse_<original_fn_name>
 /// - intern_ is the simplest function, it is generated to be called within sl-sh to avoid writing
@@ -1605,10 +1593,10 @@ fn generate_sl_sh_fn(
     Ok(tokens)
 }
 
-/// macro that creates a bridge between rust native code and sl-sh code, specify the lisp
-/// function name to be interned with the "fn_name" attribute. This macro outputs all of the
-/// generated bridge code as well as the original function's code so it can be used
-/// by the generated bridge code.
+/// macro that creates a bridge between rust native code and sl-sh code. Specify the lisp
+/// function name to be interned with the "fn_name" attribute. This macro outputs
+/// a function with a slosh compatible signature as well as a helper intern function
+/// to be called with the environment to add the function.
 #[proc_macro_attribute]
 pub fn sl_sh_fn(
     attr: proc_macro::TokenStream,

--- a/builtins/src/collections.rs
+++ b/builtins/src/collections.rs
@@ -125,6 +125,7 @@ pub fn hash_hashkey(environment: &mut SloshVm, map: &VMHashMap, key: Value) -> V
 }
 
 /// Usage: (occurs (list 1 2 ...) 7)
+///
 /// Counts instances of item in sequence.
 ///
 /// Section: core

--- a/builtins/src/collections.rs
+++ b/builtins/src/collections.rs
@@ -125,7 +125,6 @@ pub fn hash_hashkey(environment: &mut SloshVm, map: &VMHashMap, key: Value) -> V
 }
 
 /// Usage: (occurs (list 1 2 ...) 7)
-///
 /// Counts instances of item in sequence.
 ///
 /// Section: core

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -38,7 +38,7 @@ pub fn noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value
         noop_swap_internal(environment, fcn, NoopSwap::MakeNoop)
     } else {
         Err(VMError::new_vm(
-            "noop-swap: takes one argument, a builtin function to swap with noop.".to_string(),
+            "noop-fn: takes one argument, a builtin function to swap with noop.".to_string(),
         ))
     }
 }
@@ -50,12 +50,14 @@ pub fn un_noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Va
         noop_swap_internal(environment, fcn, NoopSwap::MakeNotNoop)
     } else {
         Err(VMError::new_vm(
-            "noop-swap: takes one argument, a builtin function to swap with noop.".to_string(),
+            "un-noop-fn: takes one argument, a builtin function to verify is not set to noop."
+                .to_string(),
         ))
     }
 }
 
 /// Helper enum to "force" a given function to be noop'ed or not.
+#[derive(Debug, Copy, Clone)]
 pub enum NoopSwap {
     MakeNoop,
     MakeNotNoop,
@@ -74,15 +76,17 @@ pub fn noop_swap_internal(
         // is currently set to noop
         if let Some(original_value) = environment.env_mut().remove_noop(fcn) {
             environment.set_global(sym_slot, original_value);
+            return Ok(Value::True);
         }
     } else if matches!(force_noop, NoopSwap::MakeNoop) {
         // value is *not* noop, save off the original value and then replace the slot with the
         // noop value.
         let _ = environment.env_mut().save_noop(fcn, inplace_val);
         environment.set_global(sym_slot, noop_val);
+        return Ok(Value::True);
     }
 
-    Ok(Value::Nil)
+    Ok(Value::False)
 }
 
 fn is_noop(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
@@ -101,7 +105,7 @@ fn is_noop(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
         }
     } else {
         Err(VMError::new_vm(
-            "noop-swap: takes one argument, a builtin function to swap with noop.".to_string(),
+            "is-noop: takes one argument, a builtin function to check whether or not it is currently set to noop.".to_string(),
         ))
     }
 }

--- a/builtins/src/print.rs
+++ b/builtins/src/print.rs
@@ -101,11 +101,19 @@ pub fn pretty_value(vm: &SloshVm, val: Value) -> String {
     }
 }
 
+pub fn _pr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
+    Ok(Value::Nil)
+}
+
 pub fn pr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         print!("{}", pretty_value(vm, *v));
     }
     stdout().flush()?;
+    Ok(Value::Nil)
+}
+
+pub fn _epr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -117,11 +125,19 @@ pub fn epr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
+pub fn _prn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
+    Ok(Value::Nil)
+}
+
 pub fn prn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         print!("{}", pretty_value(vm, *v));
     }
     println!();
+    Ok(Value::Nil)
+}
+
+pub fn _fpr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -141,6 +157,10 @@ pub fn fpr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
+pub fn _fprn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
+    Ok(Value::Nil)
+}
+
 pub fn fprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     let mut args = registers.iter();
     if let Some(Value::Io(h)) = args.next() {
@@ -158,11 +178,19 @@ pub fn fprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
+pub fn _eprn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
+    Ok(Value::Nil)
+}
+
 pub fn eprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         eprint!("{}", pretty_value(vm, *v));
     }
     eprintln!();
+    Ok(Value::Nil)
+}
+
+pub fn _dasm(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -202,12 +230,24 @@ pub fn dasm(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
-pub fn add_print_builtins(env: &mut SloshVm) {
-    env.set_global_builtin("pr", pr);
-    env.set_global_builtin("epr", epr);
-    env.set_global_builtin("prn", prn);
-    env.set_global_builtin("eprn", eprn);
-    env.set_global_builtin("dasm", dasm);
-    env.set_global_builtin("fpr", fpr);
-    env.set_global_builtin("fprn", fprn);
+/// noop set to true means every command that would write to stdout/stderr
+/// instead does nothing.
+pub fn add_print_builtins(env: &mut SloshVm, noop: bool) {
+    if noop {
+        env.set_global_builtin("pr", _pr);
+        env.set_global_builtin("epr", _epr);
+        env.set_global_builtin("prn", _prn);
+        env.set_global_builtin("eprn", _eprn);
+        env.set_global_builtin("dasm", _dasm);
+        env.set_global_builtin("fpr", _fpr);
+        env.set_global_builtin("fprn", _fprn);
+    } else {
+        env.set_global_builtin("pr", pr);
+        env.set_global_builtin("epr", epr);
+        env.set_global_builtin("prn", prn);
+        env.set_global_builtin("eprn", eprn);
+        env.set_global_builtin("dasm", dasm);
+        env.set_global_builtin("fpr", fpr);
+        env.set_global_builtin("fprn", fprn);
+    }
 }

--- a/builtins/src/print.rs
+++ b/builtins/src/print.rs
@@ -1,4 +1,5 @@
 use crate::SloshVm;
+use bridge_macros::sl_sh_fn;
 use compile_state::state::{CompileState, SloshVmTrait};
 use sl_compiler::compile;
 use sl_compiler::pass1::pass1;
@@ -166,6 +167,21 @@ pub fn eprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
+/// Usage: (dump-globals)
+///
+/// Prints the global variables to stdout.
+///
+/// Section: core
+///
+/// Example:
+/// #t
+#[sl_sh_fn(fn_name = "dump-globals", takes_env = true)]
+pub fn dump_globals(environment: &mut SloshVm) -> VMResult<Value> {
+    environment.dump_globals();
+    Ok(Value::Nil)
+}
+
+/// TODO PC make the other builtins.
 pub fn dasm(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() != 1 {
         return Err(VMError::new_compile(
@@ -207,7 +223,9 @@ pub fn add_print_builtins(env: &mut SloshVm) {
     env.set_global_builtin("epr", epr);
     env.set_global_builtin("prn", prn);
     env.set_global_builtin("eprn", eprn);
+    env.set_global_builtin("dump-globals", dasm);
     env.set_global_builtin("dasm", dasm);
     env.set_global_builtin("fpr", fpr);
     env.set_global_builtin("fprn", fprn);
+    intern_dump_globals(env);
 }

--- a/builtins/src/print.rs
+++ b/builtins/src/print.rs
@@ -101,23 +101,11 @@ pub fn pretty_value(vm: &SloshVm, val: Value) -> String {
     }
 }
 
-pub fn noop_fn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
-    Ok(Value::Nil)
-}
-
-pub fn _pr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
-    Ok(Value::Nil)
-}
-
 pub fn pr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         print!("{}", pretty_value(vm, *v));
     }
     stdout().flush()?;
-    Ok(Value::Nil)
-}
-
-pub fn _epr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -129,19 +117,11 @@ pub fn epr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
-pub fn _prn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
-    Ok(Value::Nil)
-}
-
 pub fn prn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         print!("{}", pretty_value(vm, *v));
     }
     println!();
-    Ok(Value::Nil)
-}
-
-pub fn _fpr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -161,10 +141,6 @@ pub fn fpr(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
-pub fn _fprn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
-    Ok(Value::Nil)
-}
-
 pub fn fprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     let mut args = registers.iter();
     if let Some(Value::Io(h)) = args.next() {
@@ -182,19 +158,11 @@ pub fn fprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
-pub fn _eprn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
-    Ok(Value::Nil)
-}
-
 pub fn eprn(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     for v in registers {
         eprint!("{}", pretty_value(vm, *v));
     }
     eprintln!();
-    Ok(Value::Nil)
-}
-
-pub fn _dasm(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
 
@@ -234,23 +202,12 @@ pub fn dasm(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
-/// noop set to true means every command that would write to stdout/stderr
-/// instead does nothing.
-pub fn add_print_builtins(env: &mut SloshVm, noop: bool) {
-    env.set_global_builtin("noop", noop_fn);
-    if noop {
-        env.set_global_builtin("pr", _pr);
-        env.set_global_builtin("prn", _prn);
-        env.set_global_builtin("epr", _epr);
-        env.set_global_builtin("eprn", _eprn);
-        env.set_global_builtin("dasm", _dasm);
-    } else {
-        env.set_global_builtin("pr", pr);
-        env.set_global_builtin("prn", prn);
-        env.set_global_builtin("epr", epr);
-        env.set_global_builtin("eprn", eprn);
-        env.set_global_builtin("dasm", dasm);
-    }
+pub fn add_print_builtins(env: &mut SloshVm) {
+    env.set_global_builtin("pr", pr);
+    env.set_global_builtin("epr", epr);
+    env.set_global_builtin("prn", prn);
+    env.set_global_builtin("eprn", eprn);
+    env.set_global_builtin("dasm", dasm);
     env.set_global_builtin("fpr", fpr);
     env.set_global_builtin("fprn", fprn);
 }

--- a/builtins/src/print.rs
+++ b/builtins/src/print.rs
@@ -101,6 +101,10 @@ pub fn pretty_value(vm: &SloshVm, val: Value) -> String {
     }
 }
 
+pub fn noop_fn(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
+    Ok(Value::Nil)
+}
+
 pub fn _pr(_vm: &mut SloshVm, _registers: &[Value]) -> VMResult<Value> {
     Ok(Value::Nil)
 }
@@ -233,21 +237,20 @@ pub fn dasm(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
 /// noop set to true means every command that would write to stdout/stderr
 /// instead does nothing.
 pub fn add_print_builtins(env: &mut SloshVm, noop: bool) {
+    env.set_global_builtin("noop", noop_fn);
     if noop {
         env.set_global_builtin("pr", _pr);
-        env.set_global_builtin("epr", _epr);
         env.set_global_builtin("prn", _prn);
+        env.set_global_builtin("epr", _epr);
         env.set_global_builtin("eprn", _eprn);
         env.set_global_builtin("dasm", _dasm);
-        env.set_global_builtin("fpr", _fpr);
-        env.set_global_builtin("fprn", _fprn);
     } else {
         env.set_global_builtin("pr", pr);
-        env.set_global_builtin("epr", epr);
         env.set_global_builtin("prn", prn);
+        env.set_global_builtin("epr", epr);
         env.set_global_builtin("eprn", eprn);
         env.set_global_builtin("dasm", dasm);
-        env.set_global_builtin("fpr", fpr);
-        env.set_global_builtin("fprn", fprn);
     }
+    env.set_global_builtin("fpr", fpr);
+    env.set_global_builtin("fprn", fprn);
 }

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1352,7 +1352,7 @@ impl CompileEnvironment {
     }
 
     /// Set a given functions original builtin function so that it can be replaced
-    /// with noop but mapped back later.
+    /// with noop fn but mapped back later.
     pub fn save_noop(&mut self, s: String, v: Value) -> Option<Value> {
         self.noop_map.insert(s, v)
     }
@@ -1371,7 +1371,6 @@ pub trait SloshVmTrait {
     fn get_reserve_global(&mut self, symbol: Interned) -> u32;
     fn set_named_global(&mut self, string: &str, value: Value) -> u32;
     fn set_global_builtin(&mut self, string: &str, func: CallFuncSig<CompileEnvironment>) -> u32;
-    //fn swap_global_builtin(&mut self, swap_string: &str, swap_func: CallFuncSig<CompileEnvironment>, string: &str, func: CallFuncSig<CompileEnvironment>);
     fn dump_globals(&self);
     fn globals(&self) -> &HashMap<Interned, usize>;
     fn own_line(&self) -> Option<u32>;
@@ -1424,19 +1423,6 @@ impl SloshVmTrait for SloshVm {
         let f_val = self.add_builtin(func);
         self.set_named_global(string, f_val)
     }
-
-//    fn swap_global_builtin(&mut self, swap_string: &str, swap_func: CallFuncSig<CompileEnvironment>, string: &str, //func: CallFuncSig<CompileEnvironment>) {
-//        let swap_sym = self.intern(swap_string);
-//        let swap_slot = self.get_reserve_global(swap_sym);
-//        self.env().
-//
-//        let sym = self.intern(string);
-//        let slot = self.get_reserve_global(sym);
-//
-//        let swap_val = self.get_global(swap_slot);
-//        let val = self.get_global(swap_slot);
-//
-//    }
 
     fn dump_globals(&self) {
         println!("GLOBALS:");

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -1297,7 +1297,10 @@ pub struct CompileEnvironment {
     global_map: HashMap<Interned, usize>,
     gensym_idx: usize,
     namespace: Namespace,
-    /// Some functions can be swapped to/from a noop, this function tracks the values.
+    /// Some functions can be swapped to/from a noop at runtime for various reasons,
+    /// e.g. make sure nothing can write to stdout; this field tracks the [`Value`]
+    /// the function *should* point to so the user can swap that back in when they
+    /// no longer want it to be a noop.
     noop_map: HashMap<String, Value>,
 }
 
@@ -1351,14 +1354,14 @@ impl CompileEnvironment {
         &self.namespace
     }
 
-    /// Set a given functions original builtin function so that it can be replaced
+    /// Set a given function's original [`Value`] function so that it can be replaced
     /// with noop fn but mapped back later.
     pub fn save_noop(&mut self, s: String, v: Value) -> Option<Value> {
         self.noop_map.insert(s, v)
     }
 
     /// Removes a key from the map, returning the value at the key if the key was previously
-    /// in the map. This is that original builtin function's [`Value::Builtin`].
+    /// in the map. This is that original function's [`Value`].
     pub fn remove_noop(&mut self, t: impl AsRef<str>) -> Option<Value> {
         self.noop_map.remove(t.as_ref())
     }

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -13,9 +13,9 @@ code-block-label = "slosh"
 [preprocessor.slosh-eval.doc-forms]
 std-lib = true
 user = true
-user-doc-files = [
-    "~/.config/slosh/init.slosh",
-]
-user-doc-load-paths = [
-    "~/.config/slosh/",
-]
+#user-doc-files = [
+#    "~/.config/slosh/init.slosh",
+#]
+#user-doc-load-paths = [
+#    "~/.config/slosh/",
+#]

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -13,9 +13,5 @@ code-block-label = "slosh"
 [preprocessor.slosh-eval.doc-forms]
 std-lib = true
 user = true
-#user-doc-files = [
-#    "~/.config/slosh/init.slosh",
-#]
-#user-doc-load-paths = [
-#    "~/.config/slosh/",
-#]
+user-doc-files = []
+user-doc-load-paths = []

--- a/doc/mdbook-slosh-eval/Cargo.lock
+++ b/doc/mdbook-slosh-eval/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "anyhow",
  "bridge_adapters",
  "builtins",
+ "chrono",
  "clap",
  "compile_state",
  "env_logger",

--- a/doc/mdbook-slosh-eval/Cargo.toml
+++ b/doc/mdbook-slosh-eval/Cargo.toml
@@ -23,4 +23,7 @@ slvm = { path = "../../vm" }
 sl-compiler = { path = "../../compiler" }
 toml = "=0.5.11"
 
+[build-dependencies]
+chrono = "0.4.38"
+
 [workspace]

--- a/doc/mdbook-slosh-eval/build.rs
+++ b/doc/mdbook-slosh-eval/build.rs
@@ -1,0 +1,105 @@
+use std::env::consts::{ARCH, OS};
+use std::process::Command;
+
+use chrono::prelude::Utc;
+
+#[cfg(debug_assertions)]
+const BUILD_TYPE: &str = "debug";
+#[cfg(not(debug_assertions))]
+const BUILD_TYPE: &str = "release";
+
+fn main() {
+    let version_string = if have_git() {
+        format!(
+            "{} {} ({}:{}{}, {} build, {} [{}], {} UTC [{}])",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            get_branch_name(),
+            get_commit_hash(),
+            if is_working_tree_clean() { "" } else { "+" },
+            BUILD_TYPE,
+            OS,
+            ARCH,
+            Utc::now().format("%b %d %Y, %T"),
+            get_rustc_version(),
+        )
+    } else {
+        format!(
+            "{} {} ({} build, {} [{}], {} UTC [{}])",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            BUILD_TYPE,
+            OS,
+            ARCH,
+            Utc::now().format("%b %d %Y, %T"),
+            get_rustc_version(),
+        )
+    };
+
+    println!("cargo:rustc-env=VERSION_STRING={}", version_string);
+}
+
+fn have_git() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .is_ok()
+}
+
+fn get_commit_hash() -> String {
+    let output = Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--pretty=format:%h") // Abbreviated commit hash
+        // .arg("--pretty=format:%H") // Full commit hash
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn get_branch_name() -> String {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string()
+}
+
+fn is_working_tree_clean() -> bool {
+    let status = Command::new("git")
+        .arg("diff")
+        .arg("--quiet")
+        .arg("--exit-code")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .unwrap();
+
+    status.code().unwrap() == 0
+}
+
+fn get_rustc_version() -> String {
+    let output = Command::new("rustc")
+        .arg("--version")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string()
+}

--- a/doc/mdbook-slosh-eval/src/main.rs
+++ b/doc/mdbook-slosh-eval/src/main.rs
@@ -299,7 +299,8 @@ mod slosh_eval_lib {
                     vm.pause_gc();
                     slosh_test_lib::vm_with_builtins_and_core(&mut vm, false);
                     vm.unpause_gc();
-                    let provided_sections = docs::get_slosh_docs(&mut vm, &mut book, false).unwrap_or_default();
+                    let provided_sections =
+                        docs::get_slosh_docs(&mut vm, &mut book, false).unwrap_or_default();
 
                     let modify_vm_local = |vm: &mut SloshVm| {
                         modify_vm(vm);
@@ -315,20 +316,20 @@ mod slosh_eval_lib {
                         slosh_test_lib::vm_with_builtins_and_core(vm, true);
                         vm.unpause_gc();
 
-                            vm.pause_gc();
-                            // then load init.slosh
-                            slosh_lib::load_sloshrc(vm, None);
-                            slosh_test_lib::add_user_builtins(
-                                vm,
-                                user_load_paths.as_slice(),
-                                user_files.as_slice(),
-                            );
-                            vm.unpause_gc();
-                            let _ = docs::add_user_docs_to_mdbook_less_provided_sections(
-                                vm,
-                                &mut book,
-                                provided_sections,
-                            );
+                        vm.pause_gc();
+                        // then load init.slosh
+                        slosh_lib::load_sloshrc(vm, None);
+                        slosh_test_lib::add_user_builtins(
+                            vm,
+                            user_load_paths.as_slice(),
+                            user_files.as_slice(),
+                        );
+                        vm.unpause_gc();
+                        let _ = docs::add_user_docs_to_mdbook_less_provided_sections(
+                            vm,
+                            &mut book,
+                            provided_sections,
+                        );
                     };
                     let _ = slosh_lib::run_slosh(modify_vm_local);
                 }

--- a/doc/mdbook-slosh-eval/src/main.rs
+++ b/doc/mdbook-slosh-eval/src/main.rs
@@ -295,6 +295,7 @@ mod slosh_eval_lib {
 
                 if gen_user_docs {
                     let modify_vm_local = |vm: &mut SloshVm| {
+                        slosh_test_lib::vm_with_stdout_disabled(vm);
                         modify_vm(vm);
 
                         if user_files.is_empty() {
@@ -304,7 +305,6 @@ mod slosh_eval_lib {
                             user_load_paths = vec!["~/.config/slosh/".to_string()];
                         }
 
-                        let vm = &mut state::new_slosh_vm();
                         vm.pause_gc();
                         slosh_test_lib::vm_with_builtins_and_core(vm, true);
                         vm.unpause_gc();
@@ -315,6 +315,7 @@ mod slosh_eval_lib {
                         {
                             vm.pause_gc();
                             // then load init.slosh
+                            slosh_lib::load_sloshrc(vm, None);
                             slosh_test_lib::add_user_builtins(
                                 vm,
                                 user_load_paths.as_slice(),
@@ -328,7 +329,7 @@ mod slosh_eval_lib {
                             );
                         }
                     };
-                    let _vm = slosh_lib::run_slosh_print_noop(modify_vm_local, true);
+                    let _vm = slosh_lib::run_slosh(modify_vm_local);
                 }
 
                 let key = "code-block-label";

--- a/doc/mdbook-slosh-eval/src/main.rs
+++ b/doc/mdbook-slosh-eval/src/main.rs
@@ -295,7 +295,6 @@ mod slosh_eval_lib {
 
                 if gen_user_docs {
                     let modify_vm_local = |vm: &mut SloshVm| {
-                        slosh_test_lib::vm_with_stdout_disabled(vm);
                         modify_vm(vm);
 
                         if user_files.is_empty() {

--- a/doc/mk-site.sh
+++ b/doc/mk-site.sh
@@ -5,15 +5,15 @@ echo "Building docs."
 
 if [ "${SKIP_SUPPLEMENTAL}" != "SKIP_SUPPLEMENTAL" ]; then
     # don't want git submodules
-    rm -rf legacy/.git || true
-    mkdir slosh-rust-docs || true
-    mkdir all-rust-docs || true
+    rm -rf src/legacy/.git || true
+    mkdir -p src/slosh-rust-docs || true
+    mkdir -p src/all-rust-docs || true
 
     cargo doc --features lisp-test --target-dir all-rust-docs
     cargo doc --no-deps --document-private-items --features lisp-test --target-dir slosh-rust-docs
 
     # clone in the legacy docs
-    git clone -b gh-pages-legacy-html https://github.com/sl-sh-dev/sl-sh legacy/ || true
+    git clone -b gh-pages-legacy-html https://github.com/sl-sh-dev/sl-sh src/legacy/ || true
 else
     echo "Skipped supplemental doc building"
 fi

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 # Basics
 - [Welcome](./welcome.md)
+- [Overview](./overview.md)
 
 # Shell Basics
 - [Shell Commands in Lisp](./shell-vs-lisp.md)

--- a/doc/src/overview.md
+++ b/doc/src/overview.md
@@ -1,0 +1,3 @@
+# The Readme
+
+{{#include ../../README.md}}

--- a/slosh/src/main.rs
+++ b/slosh/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use compiler_test_utils::exec;
-    use slosh_lib::{set_builtins_shell, set_initial_load_path, ENV};
+    use slosh_lib::{set_builtins_and_shell_builtins, set_initial_load_path, ENV};
     use slvm::{from_i56, Value};
     use std::fs::{create_dir_all, File};
     use std::io::Write;
@@ -67,7 +67,7 @@ mod tests {
         let v = temp_env::with_var("HOME", home_dir, || {
             ENV.with(|env| {
                 let mut vm = env.borrow_mut();
-                set_builtins_shell(vm.deref_mut());
+                set_builtins_and_shell_builtins(vm.deref_mut());
                 set_initial_load_path(
                     vm.deref_mut(),
                     vec![

--- a/slosh_lib/src/lib.rs
+++ b/slosh_lib/src/lib.rs
@@ -400,6 +400,8 @@ pub fn usage(vm: &mut SloshVm, slot: u32, sym: &Value) -> String {
     doc_str
 }
 
+/// All rust based slosh builtins. These functions only prime the vm w/ new functions
+/// and do not have any side-effects.
 pub fn set_builtins(env: &mut SloshVm) {
     setup_collection_builtins(env);
     add_print_builtins(env);
@@ -416,6 +418,8 @@ pub fn set_builtins(env: &mut SloshVm) {
     add_math_builtins(env);
 }
 
+/// Loads the user's sloshrc file, has side-effects, and sets some important
+/// constants in the environment.
 pub fn set_environment(env: &mut SloshVm) {
     intern_load_sloshrc(env);
 
@@ -523,8 +527,8 @@ pub fn run_slosh(modify_vm: impl FnOnce(&mut SloshVm)) -> i32 {
             let mut env = renv.borrow_mut();
             env.pause_gc();
             set_builtins(&mut env);
-            set_shell_builtins(&mut env);
             modify_vm(&mut env);
+            set_shell_builtins(&mut env);
             env.unpause_gc();
         });
         if config.command.is_none() && config.script.is_none() {

--- a/slosh_lib/src/lib.rs
+++ b/slosh_lib/src/lib.rs
@@ -507,15 +507,15 @@ pub fn set_builtins_shell_print_noop(env: &mut SloshVm, print_noop: bool) {
     export_args(env);
 }
 
-pub fn run(modify_vm: impl FnOnce(&mut SloshVm) -> ()) -> i32 {
+pub fn run(modify_vm: impl FnOnce(&mut SloshVm)) -> i32 {
     run_slosh(modify_vm)
 }
 
-fn run_slosh(modify_vm: impl FnOnce(&mut SloshVm) -> ()) -> i32 {
+fn run_slosh(modify_vm: impl FnOnce(&mut SloshVm)) -> i32 {
     run_slosh_print_noop(modify_vm, false)
 }
 
-pub fn run_slosh_print_noop(modify_vm: impl FnOnce(&mut SloshVm) -> (), print_noop: bool) -> i32 {
+pub fn run_slosh_print_noop(modify_vm: impl FnOnce(&mut SloshVm), print_noop: bool) -> i32 {
     let mut status = 0;
     if let Some(config) = get_config() {
         ENV.with(|renv| {

--- a/slosh_test/src/main.rs
+++ b/slosh_test/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use compiler_test_utils::exec;
-    use slosh_lib::{set_builtins_shell, set_initial_load_path, ENV};
+    use slosh_lib::{set_builtins_and_shell_builtins, set_initial_load_path, ENV};
     use slvm::{from_i56, Value};
     use std::fs::{create_dir_all, File};
     use std::io::Write;
@@ -74,7 +74,7 @@ mod tests {
         let v = temp_env::with_var("HOME", home_dir, || {
             ENV.with(|env| {
                 let mut vm = env.borrow_mut();
-                set_builtins_shell(vm.deref_mut());
+                set_builtins_and_shell_builtins(vm.deref_mut());
                 set_initial_load_path(
                     vm.deref_mut(),
                     vec![

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -58,10 +58,7 @@ lazy_static! {
         exemption_set.insert("return");
         exemption_set.insert("*euid*");
         exemption_set.insert("*last-status*");
-        exemption_set.insert("set-prop");
-        exemption_set.insert("sizeof-heap-object");
         exemption_set.insert("*int-min*");
-        exemption_set.insert("gensym");
         exemption_set.insert("*uid*");
         exemption_set.insert("*int-max*");
         exemption_set.insert("prn");
@@ -70,18 +67,11 @@ lazy_static! {
         exemption_set.insert("fpr");
         exemption_set.insert("eprn");
         exemption_set.insert("epr");
-        exemption_set.insert("sizeof-value");
         exemption_set.insert("dump-regs");
         exemption_set.insert("dasm");
         exemption_set.insert("*int-bits*");
-        exemption_set.insert("get-prop");
-        exemption_set.insert("expand-macro");
         exemption_set.insert("*stdout*");
         exemption_set.insert("*prn*");
-        exemption_set.insert("noop");
-        exemption_set.insert("is-noop");
-        exemption_set.insert("noop-fn");
-        exemption_set.insert("un-noop-fn");
 
         // slosh specific colors
         exemption_set.insert("get-rgb-seq");

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -726,10 +726,10 @@ fn build_sl_sh_transition_chapter(vm: &mut SloshVm) -> VMResult<Chapter> {
 }
 
 /// Convention is that the section that enumerates all of the forms by section
-/// ([`add_slosh_docs_to_mdbook`]) is added to [`MDBook`] and then the supplementary materials
+/// ([`get_slosh_docs`]) is added to [`MDBook`] and then the supplementary materials
 /// ([`link_supplementary_docs`]).
 pub fn add_forms_and_supplementary_docs(vm: &mut SloshVm, md_book: &mut Book) -> VMResult<()> {
-    add_slosh_docs_to_mdbook(vm, md_book, true)?;
+    get_slosh_docs(vm, md_book, true)?;
     link_supplementary_docs(vm, md_book)?;
     Ok(())
 }
@@ -749,15 +749,16 @@ pub fn link_supplementary_docs(vm: &mut SloshVm, md_book: &mut Book) -> VMResult
         ("Legacy sl-sh Documentation", "legacy/index.html"),
     ];
     for (section_name, section_link) in sections.into_iter() {
-        let content = format!("[{}] ", section_name); //, section_link);
+        let content = format!("[{}] ", section_name);
         let section_chapter = Chapter::new(section_name, content, section_link, vec![]);
         md_book.push_item(BookItem::Chapter(section_chapter));
     }
     Ok(())
 }
 
-/// Group documentation as specified in each documentation's designated `Section:`.
-pub fn add_slosh_docs_to_mdbook(
+/// Retrieve the docs for each section. Optional side-effects write docs to provided [`Book`] if toggled
+/// with bool).
+pub fn get_slosh_docs(
     vm: &mut SloshVm,
     md_book: &mut Book,
     write_to_book: bool,

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -78,6 +78,10 @@ lazy_static! {
         exemption_set.insert("expand-macro");
         exemption_set.insert("*stdout*");
         exemption_set.insert("*prn*");
+        exemption_set.insert("noop");
+        exemption_set.insert("is-noop");
+        exemption_set.insert("noop-fn");
+        exemption_set.insert("un-noop-fn");
 
         // slosh specific colors
         exemption_set.insert("get-rgb-seq");
@@ -1003,7 +1007,7 @@ mod test {
     use super::*;
     use compile_state::state::new_slosh_vm;
     use sl_compiler::Reader;
-    use slosh_lib::{run_reader, set_builtins_shell, set_initial_load_path, ENV};
+    use slosh_lib::{run_reader, set_builtins_and_shell_builtins, set_initial_load_path, ENV};
     use std::collections::BTreeMap;
     use std::ops::DerefMut;
     use tempfile::TempDir;
@@ -1020,7 +1024,7 @@ mod test {
         temp_env::with_var("HOME", home_dir, || {
             ENV.with(|env| {
                 let mut vm = env.borrow_mut();
-                set_builtins_shell(vm.deref_mut());
+                set_builtins_and_shell_builtins(vm.deref_mut());
                 set_initial_load_path(vm.deref_mut(), vec![&home_path]);
                 let mut reader =
                     Reader::from_string(r#"(load "core.slosh")"#.to_string(), &mut vm, "", 1, 0);
@@ -1054,7 +1058,7 @@ mod test {
     #[test]
     fn list_slosh_functions() {
         let mut vm = new_slosh_vm();
-        set_builtins_shell(&mut vm);
+        set_builtins_and_shell_builtins(&mut vm);
         for (g, _) in vm.globals() {
             let sym = Value::Symbol(*g);
             let symbol = sym.display_value(&vm);
@@ -1066,7 +1070,7 @@ mod test {
     #[test]
     fn test_global_slosh_docs_formatted_properly() {
         let mut env = new_slosh_vm();
-        set_builtins_shell(&mut env);
+        set_builtins_and_shell_builtins(&mut env);
 
         let mut docs: Vec<SloshDoc> = vec![];
         Namespace::Global

--- a/slosh_test_lib/src/lib.rs
+++ b/slosh_test_lib/src/lib.rs
@@ -33,7 +33,11 @@ pub fn add_user_builtins(env: &mut SloshVm, load_paths: &[String], files_to_load
 
     let load_paths: Vec<&str> = load_paths.iter().map(AsRef::as_ref).collect();
     slosh_lib::set_initial_load_path(env, load_paths);
-    slosh_lib::load_sloshrc(env, None);
+    for script in files_to_load {
+        let script = env.intern(script);
+        let script = env.get_interned(script);
+        let _ = load_eval::load_internal(env, script);
+    }
 }
 
 fn fake_version(vm: &mut SloshVm, registers: &[slvm::Value]) -> VMResult<slvm::Value> {

--- a/slosh_test_lib/src/lib.rs
+++ b/slosh_test_lib/src/lib.rs
@@ -10,10 +10,11 @@ pub fn vm_with_stdout_disabled(env: &mut SloshVm) {
     let _ = noop_swap_internal(env, "pr".to_string(), NoopSwap::MakeNoop);
     let _ = noop_swap_internal(env, "prn".to_string(), NoopSwap::MakeNoop);
     let _ = noop_swap_internal(env, "dasm".to_string(), NoopSwap::MakeNoop);
+    let _ = noop_swap_internal(env, "dump-globals".to_string(), NoopSwap::MakeNoop);
 }
 
 /// If noop_stdout is set to true then all functions that write to stdout
-/// (pr/prn/dasm) will be overwritten with the noop function.
+/// (pr/prn/dasm/dump-globals) will be overwritten with the noop function.
 pub fn vm_with_builtins_and_core(env: &mut SloshVm, noop_stdout: bool) {
     docs::add_builtins(env);
     slosh_lib::set_builtins(env);

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -166,21 +166,26 @@ pub fn to_i56(i: i64) -> Value {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Value {
     Byte(u8),
-    Int([u8; 7]),      // Store a 7 byte int (i56...).
-    Float(float::F56), // Replace with float::F32Wrap if desired
+    /// Store a 7 byte int (i56...).
+    Int([u8; 7]),
+    /// Replace with float::F32Wrap if desired
+    Float(float::F56),
     CodePoint(char),
     CharCluster(u8, [u8; 6]),
-    CharClusterLong(Handle), // Handle points to a String on the heap.
+    /// Handle points to a String on the heap.
+    CharClusterLong(Handle),
     Symbol(Interned),
     Keyword(Interned),
     StringConst(Interned),
-    Special(Interned), // Intended for symbols that are compiled.
+    /// Intended for symbols that are compiled.
+    Special(Interned),
     Builtin(u32),
     True,
     False,
     Nil,
+    /// Value is a placeholder only, should never appear at runtime. Can be
+    /// instantiated at times as a placeholder but should always be overwritten.
     Undefined,
-
     String(Handle),
     Vector(Handle),
     Map(Handle),


### PR DESCRIPTION
new builtin functions to swap out builtin functions with the builtin noop function (returns Nil) and back. Used by the mdbook slosh eval crate to disallow writing to stdout by temporarily making pr/prn/dasm return Nil (noop).