### PR TITLE
PR #1: Std lib/env

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -78,8 +78,8 @@ jobs:
           --threshold-measure estimated_cycles \
           --threshold-min-sample-size 4 \
           --threshold-test z_score \
-          --threshold-lower-boundary 0.977 \
-          --threshold-upper-boundary 0.977 \
+          --threshold-lower-boundary 0.95 \
+          --threshold-upper-boundary 0.95 \
           --branch-reset \
           "cargo bench --all"
 
@@ -132,7 +132,7 @@ jobs:
           --threshold-measure latency \
           --threshold-min-sample-size 4 \
           --threshold-test z_score \
-          --threshold-lower-boundary 0.977 \
-          --threshold-upper-boundary 0.977 \
+          --threshold-lower-boundary 0.95 \
+          --threshold-upper-boundary 0.95 \
           --branch-reset \
           "cargo bench --all"

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -78,8 +78,8 @@ jobs:
           --threshold-measure estimated_cycles \
           --threshold-min-sample-size 4 \
           --threshold-test z_score \
-          --threshold-lower-boundary 0.95 \
-          --threshold-upper-boundary 0.95 \
+          --threshold-lower-boundary 0.90 \
+          --threshold-upper-boundary 0.90 \
           --branch-reset \
           "cargo bench --all"
 

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -78,8 +78,8 @@ jobs:
           --threshold-measure estimated_cycles \
           --threshold-min-sample-size 4 \
           --threshold-test z_score \
-          --threshold-lower-boundary 0.95 \
-          --threshold-upper-boundary 0.95 \
+          --threshold-lower-boundary 0.977 \
+          --threshold-upper-boundary 0.977 \
           --branch-reset \
           "cargo bench --all"
 

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -75,6 +75,11 @@ jobs:
           --err \
           --branch "${BRANCH}" \
           --branch-start-point "main" \
+          --threshold-measure estimated_cycles \
+          --threshold-min-sample-size 4 \
+          --threshold-test z_score \
+          --threshold-lower-boundary 0.977 \
+          --threshold-upper-boundary 0.977 \
           --branch-reset \
           "cargo bench --all"
 
@@ -124,5 +129,10 @@ jobs:
           --err \
           --branch "$BRANCH" \
           --branch-start-point "main" \
+          --threshold-measure latency \
+          --threshold-min-sample-size 4 \
+          --threshold-test z_score \
+          --threshold-lower-boundary 0.977 \
+          --threshold-upper-boundary 0.977 \
           --branch-reset \
           "cargo bench --all"

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -78,8 +78,8 @@ jobs:
           --threshold-measure estimated_cycles \
           --threshold-min-sample-size 4 \
           --threshold-test z_score \
-          --threshold-lower-boundary 0.977 \
-          --threshold-upper-boundary 0.977 \
+          --threshold-lower-boundary 0.95 \
+          --threshold-upper-boundary 0.95 \
           --branch-reset \
           "cargo bench --all"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
           cargo version
           rustc --version
-          cargo clippy --verbose -- -D warnings
+          cargo clippy --verbose -- -D warnings -A "clippy::uninlined_format_args"
     - name: Build
       run: |
           cargo version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_adapters"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "compile_state",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_macros"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "quote",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_types"
-version = "0.11.1"
+version = "0.11.2"
 
 [[package]]
 name = "bstr"
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "builtins"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -377,7 +377,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compile_state"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "slvm",
 ]
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -2080,7 +2080,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sl-compiler"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "compile_state",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "slosh"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bench_utils",
  "bridge_adapters",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_lib"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "chrono",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test_lib"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "builtins",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "slvm"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_adapters"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "compile_state",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_macros"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "quote",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_types"
-version = "0.11.2"
+version = "0.11.1"
 
 [[package]]
 name = "bstr"
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "builtins"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -377,7 +377,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compile_state"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "slvm",
 ]
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -2080,7 +2080,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sl-compiler"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "compile_state",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "slosh"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bench_utils",
  "bridge_adapters",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_lib"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "chrono",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test_lib"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "builtins",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "slvm"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_adapters"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "compile_state",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_macros"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "quote",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_types"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "bstr"
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "builtins"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -377,7 +377,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compile_state"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "slvm",
 ]
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -2080,7 +2080,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sl-compiler"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "compile_state",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "slosh"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bench_utils",
  "bridge_adapters",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_lib"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "chrono",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test_lib"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "builtins",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "slvm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ panic = "abort"
 debug = true
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.1"
 
 [workspace.dependencies]
 bridge_types = { path = "bridge_types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ panic = "abort"
 debug = true
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 
 [workspace.dependencies]
 bridge_types = { path = "bridge_types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ panic = "abort"
 debug = true
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 
 [workspace.dependencies]
 bridge_types = { path = "bridge_types" }

--- a/builtins/src/fs_meta.rs
+++ b/builtins/src/fs_meta.rs
@@ -124,7 +124,7 @@ fn file_test(path: &str, test: fn(path: &Path) -> bool, fn_name: &str) -> VMResu
 
 /// Usage: (fs-fullpath "~/some/filepath/../") -> nil
 ///
-/// Return absolute `canonical` file path.
+/// Return absolute 'canonical' file path.
 ///
 /// Section: file
 ///

--- a/builtins/src/fs_meta.rs
+++ b/builtins/src/fs_meta.rs
@@ -122,6 +122,22 @@ fn file_test(path: &str, test: fn(path: &Path) -> bool, fn_name: &str) -> VMResu
     }
 }
 
+/// Usage: (fs-fullpath "~/some/filepath/../") -> nil
+///
+/// Return full filepath.
+///
+/// Section: file
+///
+/// Example:
+/// #t
+#[sl_sh_fn(fn_name = "fs-fullpath")]
+fn fs_fullpath(path: &str) -> Option<String> {
+    Path::new(path).canonicalize().ok().map(|x| {
+        let expanded = expand_tilde(x);
+        expanded.to_string_lossy().into_owned()
+    })
+}
+
 /// Usage: (fs-exists? path-to-test)
 ///
 /// Does the given path exist?
@@ -673,6 +689,7 @@ fn fs_meta(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
 
 pub fn add_fs_meta_builtins(env: &mut SloshVm) {
     intern_cd(env);
+    intern_fs_fullpath(env);
     intern_path_exists(env);
     intern_is_file(env);
     intern_is_dir(env);

--- a/builtins/src/fs_meta.rs
+++ b/builtins/src/fs_meta.rs
@@ -132,9 +132,9 @@ fn file_test(path: &str, test: fn(path: &Path) -> bool, fn_name: &str) -> VMResu
 /// #t
 #[sl_sh_fn(fn_name = "fs-fullpath")]
 fn fs_fullpath(path: &str) -> Option<String> {
-    Path::new(path).canonicalize().ok().map(|x| {
-        let expanded = expand_tilde(x);
-        expanded.to_string_lossy().into_owned()
+    let path = expand_tilde(path.into());
+    Path::new(&path).canonicalize().ok().map(|path| {
+        path.to_string_lossy().into_owned()
     })
 }
 

--- a/builtins/src/fs_meta.rs
+++ b/builtins/src/fs_meta.rs
@@ -124,7 +124,7 @@ fn file_test(path: &str, test: fn(path: &Path) -> bool, fn_name: &str) -> VMResu
 
 /// Usage: (fs-fullpath "~/some/filepath/../") -> nil
 ///
-/// Return full filepath.
+/// Return absolute `canonical` file path.
 ///
 /// Section: file
 ///

--- a/builtins/src/fs_meta.rs
+++ b/builtins/src/fs_meta.rs
@@ -133,9 +133,10 @@ fn file_test(path: &str, test: fn(path: &Path) -> bool, fn_name: &str) -> VMResu
 #[sl_sh_fn(fn_name = "fs-fullpath")]
 fn fs_fullpath(path: &str) -> Option<String> {
     let path = expand_tilde(path.into());
-    Path::new(&path).canonicalize().ok().map(|path| {
-        path.to_string_lossy().into_owned()
-    })
+    Path::new(&path)
+        .canonicalize()
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned())
 }
 
 /// Usage: (fs-exists? path-to-test)

--- a/builtins/src/io.rs
+++ b/builtins/src/io.rs
@@ -1,7 +1,6 @@
 use bridge_adapters::add_builtin;
 use compile_state::state::SloshVm;
 use slvm::{VMError, VMResult, Value};
-use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 extern crate unicode_reader;
@@ -212,52 +211,6 @@ fn fs_rm(path: String) -> VMResult<Value> {
     }
 }
 
-/// Usage: (unset-env "NAME_OF_ENVIRONMENT_VARIABLE")
-///
-/// Takes a string, checks the environment to see if the string is a valid
-/// environment variable and if it is it unsets it.
-///
-/// Section: core
-///
-/// Example:
-/// #t
-#[sl_sh_fn(fn_name = "unset-env")]
-fn unset_env(var: &str) {
-    unsafe {
-        env::remove_var(var);
-    }
-}
-
-/// Usage: (set-env "NAME_OF_ENVIRONMENT_VARIABLE" "Value variable should be assigned")
-///
-/// Takes two strings the first is the name of an environment variable, and the second is the
-/// value it should bind.
-///
-/// Section: core
-///
-/// Example:
-/// #t
-#[sl_sh_fn(fn_name = "set-env")]
-fn set_env(var: &str, value: &str) {
-    unsafe {
-        env::set_var(var, value);
-    }
-}
-
-/// Usage: (get-env "NAME_OF_ENVIRONMENT_VARIABLE")
-///
-/// Takes a string, checks the environment to see if the string is a valid
-/// environment variable and returns the value as a string, returns Nil otherwise.
-///
-/// Section: core
-///
-/// Example:
-/// #t
-#[sl_sh_fn(fn_name = "get-env")]
-fn get_env(var: &str) -> Option<String> {
-    env::var(var).ok()
-}
-
 pub fn add_io_builtins(env: &mut SloshVm) {
     intern_fs_rm(env);
 
@@ -355,7 +308,4 @@ Example:
         (test::assert-equal \"Test Line Three\n\" (read-line tst-file-read)))))
 ",
     );
-    intern_unset_env(env);
-    intern_set_env(env);
-    intern_get_env(env);
 }

--- a/builtins/src/io.rs
+++ b/builtins/src/io.rs
@@ -1,3 +1,4 @@
+use std::env;
 use bridge_adapters::add_builtin;
 use compile_state::state::SloshVm;
 use slvm::{VMError, VMResult, Value};
@@ -211,6 +212,53 @@ fn fs_rm(path: String) -> VMResult<Value> {
     }
 }
 
+
+/// Usage: (unset-env "NAME_OF_ENVIRONMENT_VARIABLE")
+///
+/// Takes a string, checks the environment to see if the string is a valid
+/// environment variable and if it is it unsets it.
+///
+/// Section: core
+///
+/// Example:
+/// #t
+#[sl_sh_fn(fn_name = "unset-env")]
+fn unset_env(var: &str) {
+    unsafe {
+        env::remove_var(var);
+    }
+}
+
+/// Usage: (set-env "NAME_OF_ENVIRONMENT_VARIABLE" "Value variable should be assigned")
+///
+/// Takes two strings the first is the name of an environment variable, and the second is the
+/// value it should bind.
+///
+/// Section: core
+///
+/// Example:
+/// #t
+#[sl_sh_fn(fn_name = "set-env")]
+fn set_env(var: &str, value: &str) {
+    unsafe {
+        env::set_var(var, value);
+    }
+}
+
+/// Usage: (get-env "NAME_OF_ENVIRONMENT_VARIABLE")
+///
+/// Takes a string, checks the environment to see if the string is a valid
+/// environment variable and returns the value as a string, returns Nil otherwise.
+///
+/// Section: core
+///
+/// Example:
+/// #t
+#[sl_sh_fn(fn_name = "get-env")]
+fn get_env(var: &str) -> Option<String> {
+    env::var(var).ok()
+}
+
 pub fn add_io_builtins(env: &mut SloshVm) {
     intern_fs_rm(env);
 
@@ -308,4 +356,7 @@ Example:
         (test::assert-equal \"Test Line Three\n\" (read-line tst-file-read)))))
 ",
     );
+    intern_unset_env(env);
+    intern_set_env(env);
+    intern_get_env(env);
 }

--- a/builtins/src/io.rs
+++ b/builtins/src/io.rs
@@ -1,7 +1,7 @@
-use std::env;
 use bridge_adapters::add_builtin;
 use compile_state::state::SloshVm;
 use slvm::{VMError, VMResult, Value};
+use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 extern crate unicode_reader;
@@ -211,7 +211,6 @@ fn fs_rm(path: String) -> VMResult<Value> {
         ))
     }
 }
-
 
 /// Usage: (unset-env "NAME_OF_ENVIRONMENT_VARIABLE")
 ///

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -214,17 +214,14 @@ fn builtin_probool(_vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     }
 }
 
-fn string_to_seed(s: &str) -> [u8; 32] {
-    let mut hasher = DefaultHasher::new();
-    s.hash(&mut hasher);
-    let hash = hasher.finish();
-
+fn string_to_seed(str_seed: &str) -> [u8; 32] {
     let mut seed = [0u8; 32];
-    seed[..8].copy_from_slice(&hash.to_le_bytes());
 
-    for i in 1..4 {
+    // Hash the string multiple times with different prefixes
+    for i in 0..4 {
         let mut hasher = DefaultHasher::new();
-        (s, i).hash(&mut hasher);
+        hasher.write_u8(i as u8); // Different prefix each time
+        hasher.write(str_seed.as_bytes());
         let hash = hasher.finish();
         seed[i * 8..(i + 1) * 8].copy_from_slice(&hash.to_le_bytes());
     }
@@ -236,7 +233,7 @@ fn string_to_seed(s: &str) -> [u8; 32] {
 ///
 /// Returns Vector of size `count` of non-negative integer(s) less than limit. Optional seed can be used
 /// for the random number generator which allows (random-seq) to behave as a pure function, each unique
-/// triple of (limit, count, seed) is equivalent to one deterministic sequence. Without seed values in
+/// triple of (`limit`, `count`, `seed`) is equivalent to one deterministic sequence. Without seed values in
 /// returned Vector are randomly selected on each invocation.
 ///
 /// Like (random) but with two additional parameters and is capable of returning a Vector of random values instead of just one.

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -9,7 +9,7 @@ use compile_state::state::SloshVm;
 use rand::rngs::{StdRng, ThreadRng};
 use slvm::{from_i56, VMError, VMResult, Value};
 use std::borrow::Cow;
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::{DefaultHasher, Hasher};
 
 fn builtin_random(_vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     let mut rng = rand::thread_rng();

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -241,7 +241,7 @@ fn string_to_seed(str_seed: &str) -> [u8; 32] {
 /// Section: random
 ///
 /// Example:
-/// (test::assert-equal (vec 2 2) (random-seq 4 2 "42"))
+/// (test::assert-equal (vec 0 4) (random-seq 4 2 "42"))
 #[sl_sh_fn(fn_name = "random-seq")]
 fn generate_random_sequence(
     limit: usize,

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -4,12 +4,12 @@ use std::iter;
 use unicode_segmentation::UnicodeSegmentation;
 
 use bridge_adapters::add_builtin;
+use bridge_macros::sl_sh_fn;
 use compile_state::state::SloshVm;
 use rand::rngs::{StdRng, ThreadRng};
 use slvm::{from_i56, VMError, VMResult, Value};
 use std::borrow::Cow;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use bridge_macros::sl_sh_fn;
 
 fn builtin_random(_vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     let mut rng = rand::thread_rng();
@@ -228,7 +228,7 @@ fn string_to_seed(s: &str) -> [u8; 32] {
         let mut hasher = DefaultHasher::new();
         (s, i).hash(&mut hasher);
         let hash = hasher.finish();
-        seed[i*8..(i+1)*8].copy_from_slice(&hash.to_le_bytes());
+        seed[i * 8..(i + 1) * 8].copy_from_slice(&hash.to_le_bytes());
     }
 
     seed
@@ -244,18 +244,18 @@ fn string_to_seed(s: &str) -> [u8; 32] {
 /// Example:
 /// (assert-eq (vec 2 2) (random-seq 4 2 "42"))
 #[sl_sh_fn(fn_name = "random-seq")]
-fn generate_random_sequence(limit: usize, count: usize, seed_string: Option<String>) -> VMResult<Vec<usize>> {
+fn generate_random_sequence(
+    limit: usize,
+    count: usize,
+    seed_string: Option<String>,
+) -> VMResult<Vec<usize>> {
     if let Some(seed_string) = seed_string {
         let seed = string_to_seed(&seed_string);
         let mut rng = StdRng::from_seed(seed);
-        Ok((0..count)
-            .map(|_| rng.gen_range(0..=limit))
-            .collect())
+        Ok((0..count).map(|_| rng.gen_range(0..=limit)).collect())
     } else {
         let mut rng = rand::thread_rng();
-        Ok((0..count)
-            .map(|_| rng.gen_range(0..=limit))
-            .collect())
+        Ok((0..count).map(|_| rng.gen_range(0..=limit)).collect())
     }
 }
 

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -219,11 +219,9 @@ fn string_to_seed(s: &str) -> [u8; 32] {
     s.hash(&mut hasher);
     let hash = hasher.finish();
 
-    // Convert u64 hash to [u8; 32] seed
     let mut seed = [0u8; 32];
     seed[..8].copy_from_slice(&hash.to_le_bytes());
 
-    // You could hash multiple times to fill more bytes if needed
     for i in 1..4 {
         let mut hasher = DefaultHasher::new();
         (s, i).hash(&mut hasher);
@@ -236,8 +234,12 @@ fn string_to_seed(s: &str) -> [u8; 32] {
 
 /// Usage: (random-seq limit count [seed])
 ///
-/// Like (random) but also accepts a count which is the number of random numbers to return in a [`Vec`]
-/// also takes an optional seed for a seeded random sequence.
+/// Returns Vector of size `count` of non-negative integer(s) less than limit. Optional seed can be used
+/// for the random number generator which allows (random-seq) to behave as a pure function, each unique
+/// triple of (limit, count, seed) is equivalent to one deterministic sequence. Without seed values in
+/// returned Vector are randomly selected on each invocation.
+///
+/// Like (random) but with two additional parameters and is capable of returning a Vector of random values instead of just one.
 ///
 /// Section: random
 ///

--- a/builtins/src/rand.rs
+++ b/builtins/src/rand.rs
@@ -244,7 +244,7 @@ fn string_to_seed(s: &str) -> [u8; 32] {
 /// Section: random
 ///
 /// Example:
-/// (assert-eq (vec 2 2) (random-seq 4 2 "42"))
+/// (test::assert-equal (vec 2 2) (random-seq 4 2 "42"))
 #[sl_sh_fn(fn_name = "random-seq")]
 fn generate_random_sequence(
     limit: usize,

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -485,14 +485,24 @@ Example:
 "),
             list_append: add_special(vm, "list-append", r#"Usage: (list-append list item)
 
-If second parameter is a list it will be appened to the first list, otherwise
-appends item to list.
+If last parameter is a list it will be appened to the first list, otherwise
+adds item as pair.
 
 Section: pair
 
 Example:
 (test::assert-equal (list-append (list 1 2 3) (list 1)) (list 1 2 3 1))
+;; demonstrates that appending two lists is different than appending a non-list value
 (test::assert-not-equal (list-append (list 1 2 3) (list 1)) (list-append (list 1 2 3) 1))
+(test::assert-equal (list 1 2 3 4 5 6 7 8 9) (list-append (list 1 2 3) (list 4 5 6) (list 7 8 9)))
+(test::assert-equal (list-append '(:a :b :c) '(:d :e :f) '() '(:g))  '(:a :b :c :d :e :f :g))
+;; TODO PC unrepresentable?
+;;(test::assert-equal (list-append '(a b c) 'd)  (A B C . D)
+(def lst '(:a :b :c))
+(test::assert-equal (list-append lst (list :d)) (list :a :b :c :d))
+(test::assert-equal lst '(:a :b :c))
+(test::assert-equal (list-append) nil)
+(test::assert-equal (list-append :a) :a)
 "#),
             cons: add_special(vm, "cons", r#"Usage: (cons item collection)
 

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -481,8 +481,23 @@ Section: pair
 
 Example:
 (test::assert-equal '(1 2 3) (list 1 2 3))"),
-            list_append: add_special(vm, "list-append", ""),
-            cons: add_special(vm, "cons", ""),
+            list_append: add_special(vm, "list-append", r#"Usage: (list-append list1 item1)
+
+If second parameter is a list it will be appened to the first list, otherwise
+treated like cons.
+
+Section: pair
+
+Example:
+(test::assert-equal (list-append (list 1 2 3) (list 1)) (list 1 2 3 1))
+(test::assert-not-equal (list-append (list 1 2 3) (list 1)) (list-append (list 1 2 3) 1))
+"#),
+            cons: add_special(vm, "cons", r#"Usage: (cons item collection)
+
+Prepends item to collection forms a pair.
+
+Section: pair
+"#),
             car: add_special(vm, "car", "Usage: (car pair)
 
 Return the car (first item) from a pair.  If used on a proper list this will be the first element.

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -480,11 +480,13 @@ Create a proper list from pairs with items 0 - N.
 Section: pair
 
 Example:
-(test::assert-equal '(1 2 3) (list 1 2 3))"),
-            list_append: add_special(vm, "list-append", r#"Usage: (list-append list1 item1)
+(test::assert-equal '(1 2 3) (list 1 2 3))
+(test::assert-not-equal (list-append (list 1 2 3) (list 1)) (list-append (list 1 2 3) 1))
+"),
+            list_append: add_special(vm, "list-append", r#"Usage: (list-append list item)
 
 If second parameter is a list it will be appened to the first list, otherwise
-treated like cons.
+appends item to list.
 
 Section: pair
 
@@ -494,9 +496,12 @@ Example:
 "#),
             cons: add_special(vm, "cons", r#"Usage: (cons item collection)
 
-Prepends item to collection forms a pair.
+Prepends item to collection, forms a pair.
 
 Section: pair
+
+Example:
+(test::assert-equal '(1 2 3) (cons 1 (list 2 3)))
 "#),
             car: add_special(vm, "car", "Usage: (car pair)
 

--- a/compile_state/src/state.rs
+++ b/compile_state/src/state.rs
@@ -481,7 +481,7 @@ Section: pair
 
 Example:
 (test::assert-equal '(1 2 3) (list 1 2 3))
-(test::assert-not-equal (list-append (list 1 2 3) (list 1)) (list-append (list 1 2 3) 1))
+(test::assert-equal '() (list))
 "),
             list_append: add_special(vm, "list-append", r#"Usage: (list-append list item)
 
@@ -497,7 +497,7 @@ Example:
 (test::assert-equal (list 1 2 3 4 5 6 7 8 9) (list-append (list 1 2 3) (list 4 5 6) (list 7 8 9)))
 (test::assert-equal (list-append '(:a :b :c) '(:d :e :f) '() '(:g))  '(:a :b :c :d :e :f :g))
 ;; TODO PC unrepresentable?
-;;(test::assert-equal (list-append '(a b c) 'd)  (A B C . D)
+(test::assert-equal (list-append '(1 2 3) 4)  '(1 2 3 . 4))
 (def lst '(:a :b :c))
 (test::assert-equal (list-append lst (list :d)) (list :a :b :c :d))
 (test::assert-equal lst '(:a :b :c))
@@ -512,6 +512,14 @@ Section: pair
 
 Example:
 (test::assert-equal '(1 2 3) (cons 1 (list 2 3)))
+(test::assert-equal (cons 1 (cons 2 (cons 3 '()))) '(1 2 3))
+(test::assert-equal (cons 1 2) (1 . 2))
+(test::assert-equal (cons 1 nil) (1))
+(test::assert-equal (cons nil 2) (nil . 3))
+(test::assert-equal (cons nil nil) (nil))
+(test::assert-equal (cons 1 (cons 2 (cons 3 (cons 4 nil)))) '(1 2 3 4))
+(test::assert-equal (cons 1 2) (1 . 2))
+(test::assert-equal (cons 1 '(2 3 4)) (1 2 3 4))
 "#),
             car: add_special(vm, "car", "Usage: (car pair)
 

--- a/doc/mdbook-slosh-eval/Cargo.lock
+++ b/doc/mdbook-slosh-eval/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_adapters"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "compile_state",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_macros"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "quote",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_types"
-version = "0.11.2"
+version = "0.11.1"
 
 [[package]]
 name = "bstr"
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "builtins"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -317,7 +317,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compile_state"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "slvm",
 ]
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1907,7 +1907,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sl-compiler"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "compile_state",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_lib"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test_lib"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_adapters",
  "builtins",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "slvm"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "bridge_types",
  "unicode-segmentation",

--- a/doc/mdbook-slosh-eval/Cargo.lock
+++ b/doc/mdbook-slosh-eval/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_adapters"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "compile_state",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_macros"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "quote",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_types"
-version = "0.11.0"
+version = "0.11.2"
 
 [[package]]
 name = "bstr"
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "builtins"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -317,7 +317,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compile_state"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "slvm",
 ]
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1907,7 +1907,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sl-compiler"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "compile_state",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_lib"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "bridge_macros",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "slosh_test_lib"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_adapters",
  "builtins",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "slvm"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "bridge_types",
  "unicode-segmentation",

--- a/shell/src/builtins.rs
+++ b/shell/src/builtins.rs
@@ -332,7 +332,7 @@ where
 {
     let mut args = args.map(|v| v.resolve_arg(jobs).unwrap_or_default());
     let command_str = command.to_string_lossy();
-    // TODO sls how can we document builtins?
+    // TODO #247 how can we document builtins?
     let status = match &*command_str {
         "cd" => {
             let arg = args.next();

--- a/shell/src/builtins.rs
+++ b/shell/src/builtins.rs
@@ -332,6 +332,7 @@ where
 {
     let mut args = args.map(|v| v.resolve_arg(jobs).unwrap_or_default());
     let command_str = command.to_string_lossy();
+    // TODO sls how can we document builtins?
     let status = match &*command_str {
         "cd" => {
             let arg = args.next();

--- a/shell/src/parse.rs
+++ b/shell/src/parse.rs
@@ -239,7 +239,7 @@ impl ParseState {
         let mut open_braces = 0;
         let mut last_ch = ' ';
         let mut quoted = false;
-        for (i, ch) in token.chars().enumerate() {
+        for (i, ch) in token.char_indices() {
             if ch == '{' && last_ch != '\\' && !quoted {
                 if open_braces == 0 {
                     open = i;

--- a/slosh/bench_utils/benches/bench.slosh
+++ b/slosh/bench_utils/benches/bench.slosh
@@ -4,13 +4,13 @@
 
 (def pu (eval-pol 100 0.5))
 (prn "(eval-pol 100 0.5) =>\n" pu)
-(prn "passed: " (equal? pu 400.0))
+(prn "passed: " (== pu 400.0))
 
 (def pu (eval-pol 1000 0.05))
 (prn "(eval-pol 1000 0.05) =>\n" pu)
-(prn "passed: " (equal? pu 2105.26315904))
+(prn "passed: " (== pu 2105.26315904))
 
 (def pu (eval-pol 10000 0.2))
 (prn "(eval-pol 10000 0.2) =>\n" pu)
-(prn "passed: " (equal? pu 25000.0))
+(prn "passed: " (== pu 25000.0))
 

--- a/slosh/bench_utils/benches/vec-search-bench.slosh
+++ b/slosh/bench_utils/benches/vec-search-bench.slosh
@@ -25,7 +25,7 @@
           (helper pred x limit)))))
 
 
-(defn is-limit (x limit) (= limit x))
+(defn is-limit (x limit) (== limit x))
 
 (defn run-recursive (limit)
     (test::assert-true (naive-recursive-find is-limit (build-vec limit limit) limit)))

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -258,11 +258,12 @@ impl DocStringSection {
                 example,
             });
         }
-        let cap = DOC_REGEX.captures(raw_doc_string.as_str()).ok_or_else(|| {
-            DocError::NoDocString {
-                symbol: symbol.to_string(),
-            }
-        })?;
+        let cap =
+            DOC_REGEX
+                .captures(raw_doc_string.as_str())
+                .ok_or_else(|| DocError::NoDocString {
+                    symbol: symbol.to_string(),
+                })?;
         let mut usage = cap.get(2).map(|x| x.as_str().trim().to_string());
         if usage.is_none() && !backup_usage.trim().is_empty() {
             usage = Some(backup_usage);

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -429,16 +429,6 @@ impl SloshDoc {
     pub fn fully_qualified_name(&self) -> String {
         self.namespace.to_string() + "::" + self.symbol.as_ref()
     }
-
-    /// Return an empty documentation map.
-    fn nil_doc_map(vm: &mut SloshVm) -> VMHashMap {
-        let mut map = VMHashMap::with_capacity(4);
-        insert_nil_section(&mut map, USAGE, vm);
-        insert_nil_section(&mut map, SECTION, vm);
-        insert_nil_section(&mut map, DESCRIPTION, vm);
-        insert_nil_section(&mut map, EXAMPLE, vm);
-        map
-    }
 }
 
 enum DocError {

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -48,7 +48,6 @@ lazy_static! {
         exemption_set.insert("sh");
         exemption_set.insert("$sh");
         exemption_set.insert("this-fn");
-        exemption_set.insert("cons");
         exemption_set.insert("identical?");
         exemption_set.insert("type");
         exemption_set.insert("call/cc");

--- a/slosh_test_lib/src/docs/legacy.rs
+++ b/slosh_test_lib/src/docs/legacy.rs
@@ -436,7 +436,7 @@ pub(crate) fn full_legacy_sl_sh_forms_metadata() -> &'static [(&'static str, boo
         ("gensym", true, ""),
         ("get-arity", true, ""),
         ("get-dirs", true, ""),
-        ("get-env", true, ""),
+        ("get-env", true, "env"),
         ("get-error", true, ""),
         ("get-home", true, ""),
         ("get-next-params", true, ""),


### PR DESCRIPTION
- doc:
   show symbols that do not have documentation on the forms page so they are more discoverable.
- bencher:
  - add thresholds so we can be notified via gh actions if a metric is lagging
- std-lib:
  - fix
     some old scripts
  - add
     get-env
     set-env
    unset-env
    fs-fullpath