### PR TITLE
new PR #1: BridgeError to add fn_name context to errors

### DIFF
--- a/bridge_adapters/src/lib.rs
+++ b/bridge_adapters/src/lib.rs
@@ -1,7 +1,32 @@
 use compile_state::state::{CompileEnvironment, SloshVm, SloshVmTrait};
-use slvm::{CallFuncSig, Value};
+use slvm::{CallFuncSig, Value, VMError, VMResult};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 
 pub mod lisp_adapters;
+
+pub type BridgeResult<T> = Result<T, BridgeError>;
+
+#[derive(Debug, Clone)]
+pub enum BridgeError {
+    Error(String),
+}
+
+impl Error for BridgeError {}
+
+impl BridgeError {
+    pub fn with_fn<T>(br: BridgeResult<T>, fn_name: impl AsRef<str>) -> VMResult<T> {
+        br.map_err(|e| VMError::new_conversion(format!("{}: {}", fn_name.as_ref(), e)))
+    }
+}
+
+impl Display for BridgeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BridgeError::Error(s) => write!(f, "{s}"),
+        }
+    }
+}
 
 pub fn add_builtin(
     env: &mut SloshVm,

--- a/bridge_adapters/src/lib.rs
+++ b/bridge_adapters/src/lib.rs
@@ -1,5 +1,5 @@
 use compile_state::state::{CompileEnvironment, SloshVm, SloshVmTrait};
-use slvm::{CallFuncSig, Value, VMError, VMResult};
+use slvm::{CallFuncSig, VMError, VMResult, Value};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 

--- a/bridge_adapters/src/lisp_adapters.rs
+++ b/bridge_adapters/src/lisp_adapters.rs
@@ -243,8 +243,8 @@ use bridge_types::BridgedType;
 use bridge_types::{Keyword, KeywordAsString, LooseString, SloshChar, Symbol, SymbolAsString};
 use compile_state::state::SloshVm;
 
-use slvm::Value;
 use crate::BridgeResult;
+use slvm::Value;
 
 mod collections;
 pub mod numbers;

--- a/bridge_adapters/src/lisp_adapters.rs
+++ b/bridge_adapters/src/lisp_adapters.rs
@@ -30,13 +30,13 @@
 //! ```ignore
 //!
 //! impl<'a> SlFromRef<'a, Value> for &'a str {
-//!     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+//!     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
 //!         (&value).sl_as_ref(vm)
 //!     }
 //! }
 //!
 //! impl<'a> SlAsRef<'a, str> for &Value {
-//!     fn sl_as_ref(&self, vm: &'a SloshVm) -> VMResult<&'a str> {
+//!     fn sl_as_ref(&self, vm: &'a SloshVm) -> BridgeResult<&'a str> {
 //!         match self {
 //!             Value::String(h) => Ok(vm.get_string(*h)),
 //!             Value::StringConst(i) => Ok(vm.get_interned(*i)),
@@ -60,13 +60,13 @@
 //! ```ignore
 //!
 //! impl<'a> SlFromRefMut<'a, Value> for &'a mut String {
-//!     fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> VMResult<Self> {
+//!     fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> BridgeResult<Self> {
 //!         (&value).sl_as_mut(vm)
 //!     }
 //! }
 //!
 //! impl<'a> SlAsMut<'a, String> for &Value {
-//!     fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> VMResult<&'a mut String> {
+//!     fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> BridgeResult<&'a mut String> {
 //!         match self {
 //!             Value::String(h) => vm.get_string_mut(*h),
 //!             _ => Err(VMError::new_conversion(
@@ -101,7 +101,7 @@
 //! TODO #220 - returning values via annotated or lifetime?
 //!  To avoid allocations when converting a slosh &Value back to a rust type that was mutated
 //!  don't return anything. If it is necessary for the API to return some value.
-//! ...either use an annotation on an input argument `fn myfun(#[likeThis] returnme: &mut String, someotherval: String) -> VMResult<()>`
+//! ...either use an annotation on an input argument `fn myfun(#[likeThis] returnme: &mut String, someotherval: String) -> BridgeResult<()>`
 //! or a lifetime... might be easier to do the annotation.
 //!
 //!
@@ -243,7 +243,9 @@ use bridge_types::BridgedType;
 use bridge_types::{Keyword, KeywordAsString, LooseString, SloshChar, Symbol, SymbolAsString};
 use compile_state::state::SloshVm;
 
-use slvm::{VMResult, Value};
+use slvm::Value;
+use crate::BridgeResult;
+
 mod collections;
 pub mod numbers;
 pub mod primitives;
@@ -255,14 +257,14 @@ where
     Self: BridgedType,
 {
     /// Converts to this type from the input type.
-    fn sl_from(value: T, vm: &mut SloshVm) -> VMResult<Self>;
+    fn sl_from(value: T, vm: &mut SloshVm) -> BridgeResult<Self>;
 }
 
 impl<T> SlFrom<Vec<T>> for Value
 where
     T: SlInto<Value>,
 {
-    fn sl_from(value: Vec<T>, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: Vec<T>, vm: &mut SloshVm) -> BridgeResult<Self> {
         let mut u = Vec::with_capacity(value.len());
         for v in value {
             u.push(v.sl_into(vm)?);
@@ -275,7 +277,7 @@ impl<'a, T> SlFromRef<'a, slvm::Value> for Vec<T>
 where
     T: SlFromRef<'a, Value> + 'a,
 {
-    fn sl_from_ref(value: slvm::Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: slvm::Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         let mut res = vec![];
         for val in value.iter(vm) {
             let t: T = val.sl_into_ref(vm)?;
@@ -291,14 +293,14 @@ where
     T: BridgedType,
 {
     /// Converts this type into the (usually inferred) input type.
-    fn sl_into(self, vm: &mut SloshVm) -> VMResult<T>;
+    fn sl_into(self, vm: &mut SloshVm) -> BridgeResult<T>;
 }
 
 impl<T, U> SlInto<U> for T
 where
     U: SlFrom<T>,
 {
-    fn sl_into(self, vm: &mut SloshVm) -> VMResult<U> {
+    fn sl_into(self, vm: &mut SloshVm) -> BridgeResult<U> {
         U::sl_from(self, vm)
     }
 }
@@ -308,7 +310,7 @@ where
     Self: Sized,
 {
     /// Converts to this type from the input type.
-    fn sl_from_ref(value: T, vm: &'a SloshVm) -> VMResult<Self>;
+    fn sl_from_ref(value: T, vm: &'a SloshVm) -> BridgeResult<Self>;
 }
 
 /// Inverse of [`SlFromRef`]
@@ -318,7 +320,7 @@ where
     Self: BridgedType,
 {
     /// Converts to this type from the input type.
-    fn sl_into_ref(self, vm: &'a SloshVm) -> VMResult<T>;
+    fn sl_into_ref(self, vm: &'a SloshVm) -> BridgeResult<T>;
 }
 
 impl<'a, T, U> SlIntoRef<'a, U> for T
@@ -327,7 +329,7 @@ where
     U: SlFromRef<'a, T>,
     U: 'a,
 {
-    fn sl_into_ref(self, vm: &'a SloshVm) -> VMResult<U> {
+    fn sl_into_ref(self, vm: &'a SloshVm) -> BridgeResult<U> {
         U::sl_from_ref(self, vm)
     }
 }
@@ -337,7 +339,7 @@ where
     Self: Sized,
 {
     /// Converts to this type from the input type.
-    fn sl_from_ref_mut(value: T, vm: &'a mut SloshVm) -> VMResult<Self>;
+    fn sl_from_ref_mut(value: T, vm: &'a mut SloshVm) -> BridgeResult<Self>;
 }
 
 /// Inverse of [`SlFromRefMut`]
@@ -347,7 +349,7 @@ where
     Self: BridgedType,
 {
     /// Converts to this type from the input type.
-    fn sl_into_ref_mut(self, vm: &'a mut SloshVm) -> VMResult<T>;
+    fn sl_into_ref_mut(self, vm: &'a mut SloshVm) -> BridgeResult<T>;
 }
 
 impl<'a, T, U> SlIntoRefMut<'a, U> for T
@@ -356,7 +358,7 @@ where
     U: SlFromRefMut<'a, T>,
     U: 'a,
 {
-    fn sl_into_ref_mut(self, vm: &'a mut SloshVm) -> VMResult<U> {
+    fn sl_into_ref_mut(self, vm: &'a mut SloshVm) -> BridgeResult<U> {
         U::sl_from_ref_mut(self, vm)
     }
 }
@@ -367,7 +369,7 @@ where
     Self: BridgedType,
 {
     /// Converts this type into a shared reference of the (usually inferred) input type.
-    fn sl_as_ref(&self, vm: &'a SloshVm) -> VMResult<&'a T>;
+    fn sl_as_ref(&self, vm: &'a SloshVm) -> BridgeResult<&'a T>;
 }
 
 // SlAsRef lifts over &
@@ -377,7 +379,7 @@ where
     &'a T: BridgedType,
 {
     #[inline]
-    fn sl_as_ref(&self, vm: &'a SloshVm) -> VMResult<&'a U> {
+    fn sl_as_ref(&self, vm: &'a SloshVm) -> BridgeResult<&'a U> {
         <T as SlAsRef<'a, U>>::sl_as_ref(*self, vm)
     }
 }
@@ -389,7 +391,7 @@ where
     &'a mut T: BridgedType,
 {
     #[inline]
-    fn sl_as_ref(&self, vm: &'a SloshVm) -> VMResult<&'a U> {
+    fn sl_as_ref(&self, vm: &'a SloshVm) -> BridgeResult<&'a U> {
         <T as SlAsRef<'a, U>>::sl_as_ref(*self, vm)
     }
 }
@@ -399,7 +401,7 @@ where
     Self: BridgedType,
 {
     /// Converts this type into a mutable reference of the (usually inferred) input type.
-    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> VMResult<&'a mut T>;
+    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> BridgeResult<&'a mut T>;
 }
 
 // SlAsMut lifts over &mut
@@ -409,13 +411,13 @@ where
     &'a mut T: BridgedType,
 {
     #[inline]
-    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> VMResult<&'a mut U> {
+    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> BridgeResult<&'a mut U> {
         (*self).sl_as_mut(vm)
     }
 }
 
 impl SlFrom<Value> for Value {
-    fn sl_from(value: Value, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: Value, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(value)
     }
 }

--- a/bridge_adapters/src/lisp_adapters.rs
+++ b/bridge_adapters/src/lisp_adapters.rs
@@ -41,7 +41,7 @@
 //!             Value::String(h) => Ok(vm.get_string(*h)),
 //!             Value::StringConst(i) => Ok(vm.get_interned(*i)),
 //!             _ => Err(VMError::new_conversion(
-//!                 ErrorStrings::fix_me_mismatched_type(
+//!                 ErrorStrings::mismatched_type(
 //!                     String::from(ValueTypes::from([
 //!                         ValueType::String,
 //!                         ValueType::StringConst,
@@ -70,7 +70,7 @@
 //!         match self {
 //!             Value::String(h) => vm.get_string_mut(*h),
 //!             _ => Err(VMError::new_conversion(
-//!                 ErrorStrings::fix_me_mismatched_type(
+//!                 ErrorStrings::mismatched_type(
 //!                     <&'static str>::from(ValueType::String),
 //!                     self.display_type(vm),
 //!                 ),

--- a/bridge_adapters/src/lisp_adapters/collections.rs
+++ b/bridge_adapters/src/lisp_adapters/collections.rs
@@ -11,7 +11,7 @@ impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
         match value {
             Value::Map(h) => Ok(vm.get_map(h)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Map),
                     value.display_type(vm),
                 ),
@@ -25,7 +25,7 @@ impl<'a> SlFromRefMut<'a, Value> for &'a mut VMHashMap {
         match value {
             Value::Map(h) => vm.get_map_mut(h).map_err(|e| BridgeError::Error(e.to_string())),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Map),
                     value.display_type(vm),
                 ),

--- a/bridge_adapters/src/lisp_adapters/collections.rs
+++ b/bridge_adapters/src/lisp_adapters/collections.rs
@@ -1,14 +1,16 @@
 use crate::lisp_adapters::{SlFromRef, SlFromRefMut};
+use crate::{BridgeResult, BridgeError};
 use bridge_types::ErrorStrings;
 use compile_state::state::SloshVm;
 use slvm::vm_hashmap::VMHashMap;
-use slvm::{VMError, VMResult, Value, ValueType};
+use slvm::{Value, ValueType};
+
 
 impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Map(h) => Ok(vm.get_map(h)),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Map),
                     value.display_type(vm),
@@ -19,10 +21,10 @@ impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
 }
 
 impl<'a> SlFromRefMut<'a, Value> for &'a mut VMHashMap {
-    fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> VMResult<Self> {
+    fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> BridgeResult<Self> {
         match value {
-            Value::Map(h) => Ok(vm.get_map_mut(h)?),
-            _ => Err(VMError::new_conversion(
+            Value::Map(h) => vm.get_map_mut(h).map_err(|e| BridgeError::Error(e.to_string())),
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Map),
                     value.display_type(vm),

--- a/bridge_adapters/src/lisp_adapters/collections.rs
+++ b/bridge_adapters/src/lisp_adapters/collections.rs
@@ -1,21 +1,18 @@
 use crate::lisp_adapters::{SlFromRef, SlFromRefMut};
-use crate::{BridgeResult, BridgeError};
+use crate::{BridgeError, BridgeResult};
 use bridge_types::ErrorStrings;
 use compile_state::state::SloshVm;
 use slvm::vm_hashmap::VMHashMap;
 use slvm::{Value, ValueType};
 
-
 impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Map(h) => Ok(vm.get_map(h)),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Map),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Map),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -23,13 +20,13 @@ impl<'a> SlFromRef<'a, Value> for &'a VMHashMap {
 impl<'a> SlFromRefMut<'a, Value> for &'a mut VMHashMap {
     fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> BridgeResult<Self> {
         match value {
-            Value::Map(h) => vm.get_map_mut(h).map_err(|e| BridgeError::Error(e.to_string())),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Map),
-                    value.display_type(vm),
-                ),
-            )),
+            Value::Map(h) => vm
+                .get_map_mut(h)
+                .map_err(|e| BridgeError::Error(e.to_string())),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Map),
+                value.display_type(vm),
+            ))),
         }
     }
 }

--- a/bridge_adapters/src/lisp_adapters/numbers.rs
+++ b/bridge_adapters/src/lisp_adapters/numbers.rs
@@ -4,7 +4,7 @@ use bridge_types::{ErrorStrings, LooseFloat, LooseInt, LooseString};
 use compile_state::state::SloshVm;
 use slvm::float::F56;
 use slvm::value::ValueType;
-use slvm::{to_i56, Value, ValueTypes, I56};
+use slvm::{I56, Value, ValueTypes, to_i56};
 
 impl SlFrom<()> for Value {
     fn sl_from(_value: (), _vm: &mut SloshVm) -> BridgeResult<Self> {

--- a/bridge_adapters/src/lisp_adapters/numbers.rs
+++ b/bridge_adapters/src/lisp_adapters/numbers.rs
@@ -1,21 +1,22 @@
 use crate::lisp_adapters::{SlFrom, SlFromRef};
+use crate::{BridgeResult, BridgeError};
 use bridge_types::{ErrorStrings, LooseFloat, LooseInt, LooseString};
 use compile_state::state::SloshVm;
 use slvm::float::F56;
 use slvm::value::ValueType;
-use slvm::{I56, VMError, VMResult, Value, ValueTypes, to_i56};
+use slvm::{to_i56, Value, ValueTypes, I56};
 
 impl SlFrom<()> for Value {
-    fn sl_from(_value: (), _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(_value: (), _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::Nil)
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for () {
-    fn sl_from_ref(value: Value, _vm: &'a SloshVm) -> VMResult<()> {
+    fn sl_from_ref(value: Value, _vm: &'a SloshVm) -> BridgeResult<()> {
         match value {
             Value::Nil => Ok(()),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Nil),
                     value.display_type(_vm),
@@ -26,7 +27,7 @@ impl<'a> SlFromRef<'a, Value> for () {
 }
 
 impl<'a> SlFromRef<'a, Value> for LooseFloat {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         let res = match value {
             Value::Byte(byte) => {
                 let f = byte as f64;
@@ -48,10 +49,10 @@ impl<'a> SlFromRef<'a, Value> for LooseFloat {
             | Value::StringConst(_)) => {
                 let f = LooseString::sl_from_ref(v, vm)?
                     .parse::<f64>()
-                    .map_err(|_e| VMError::new_string_conversion("Not a valid float."))?;
+                    .map_err(|_e| BridgeError::Error("Not a valid float.".to_string()))?;
                 Ok(F56::from(f).0)
             }
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_invalid_string(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
@@ -63,19 +64,19 @@ impl<'a> SlFromRef<'a, Value> for LooseFloat {
 }
 
 impl SlFrom<LooseFloat> for Value {
-    fn sl_from(value: LooseFloat, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: LooseFloat, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::Float(F56(value.0)))
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for LooseInt {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         let res = match value {
             Value::Byte(byte) => Ok(I56::into_inner(byte as i64)),
             Value::Int(i) => Ok(i),
             Value::Float(f) => {
                 let f = f64::from(f);
-                let i56 = I56::into_i56_fallible(f)?;
+                let i56 = I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))?;
                 Ok(I56::into_inner(i56))
             }
             v @ (Value::CodePoint(_)
@@ -88,11 +89,11 @@ impl<'a> SlFromRef<'a, Value> for LooseInt {
                 .parse::<i64>()
                 .or(LooseString::sl_from_ref(v, vm)?
                     .parse::<f64>()
-                    .map_err(|_e| VMError::new_string_conversion("Not a valid integer."))
-                    .and_then(I56::into_i56_fallible))
+                    .map_err(|_e| BridgeError::Error("Not a valid integer.".to_string()))
+                    .and_then(|f| I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))))
                 .map(I56::into_inner)
-                .map_err(|_e| VMError::new_string_conversion("Not a valid integer.")),
-            _ => Err(VMError::new_conversion(
+                .map_err(|_e| BridgeError::Error("Not a valid integer.".to_string())),
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
@@ -104,39 +105,39 @@ impl<'a> SlFromRef<'a, Value> for LooseInt {
 }
 
 impl SlFrom<LooseInt> for Value {
-    fn sl_from(value: LooseInt, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: LooseInt, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::Int(value.0))
     }
 }
 
 impl SlFrom<i32> for Value {
-    fn sl_from(value: i32, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: i32, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(to_i56(value as i64))
     }
 }
 impl SlFrom<u32> for Value {
-    fn sl_from(value: u32, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: u32, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(to_i56(value as i64))
     }
 }
 
 impl SlFrom<i64> for Value {
-    fn sl_from(value: i64, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: i64, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(to_i56(value))
     }
 }
 impl<'a> SlFromRef<'a, Value> for i32 {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<i32> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<i32> {
         match value {
             Value::Int(num) => {
                 let num = I56::from_inner(&num);
                 num.try_into().map_err(|_| {
-                    VMError::new_conversion(
+                    BridgeError::Error(
                         "Provided slosh value too small to fit desired type.".to_string(),
                     )
                 })
             }
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
@@ -147,16 +148,16 @@ impl<'a> SlFromRef<'a, Value> for i32 {
 }
 
 impl SlFrom<f64> for Value {
-    fn sl_from(value: f64, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: f64, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::Float(value.into()))
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for f64 {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Float(float) => Ok(f64::from(float)),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Float),
                     value.display_type(vm),
@@ -167,16 +168,16 @@ impl<'a> SlFromRef<'a, Value> for f64 {
 }
 
 impl SlFrom<u8> for Value {
-    fn sl_from(value: u8, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: u8, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::Byte(value))
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for u8 {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Byte(i) => Ok(i),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     String::from(ValueTypes::from([ValueType::Byte])),
                     value.display_type(vm),
@@ -187,27 +188,27 @@ impl<'a> SlFromRef<'a, Value> for u8 {
 }
 
 impl SlFrom<usize> for Value {
-    fn sl_from(value: usize, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: usize, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(to_i56(value as i64))
     }
 }
 
 impl SlFrom<u64> for Value {
-    fn sl_from(value: u64, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: u64, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(to_i56(value as i64))
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for usize {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Int(i) => usize::try_from(I56::from_inner(&i)).map_err(|_| {
-                VMError::new_conversion(ErrorStrings::fix_me_mismatched_type(
+                BridgeError::Error(ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ))
             }),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     String::from(ValueTypes::from([ValueType::Int])),
                     value.display_type(vm),
@@ -218,10 +219,10 @@ impl<'a> SlFromRef<'a, Value> for usize {
 }
 
 impl<'a> SlFromRef<'a, Value> for i64 {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Int(i) => Ok(I56::from_inner(&i)),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),

--- a/bridge_adapters/src/lisp_adapters/numbers.rs
+++ b/bridge_adapters/src/lisp_adapters/numbers.rs
@@ -17,7 +17,7 @@ impl<'a> SlFromRef<'a, Value> for () {
         match value {
             Value::Nil => Ok(()),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Nil),
                     value.display_type(_vm),
                 ),
@@ -53,7 +53,7 @@ impl<'a> SlFromRef<'a, Value> for LooseFloat {
                 Ok(F56::from(f).0)
             }
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_invalid_string(
+                ErrorStrings::invalid_string(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ),
@@ -94,7 +94,7 @@ impl<'a> SlFromRef<'a, Value> for LooseInt {
                 .map(I56::into_inner)
                 .map_err(|_e| BridgeError::Error("Not a valid integer.".to_string())),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ),
@@ -138,7 +138,7 @@ impl<'a> SlFromRef<'a, Value> for i32 {
                 })
             }
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ),
@@ -158,7 +158,7 @@ impl<'a> SlFromRef<'a, Value> for f64 {
         match value {
             Value::Float(float) => Ok(f64::from(float)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Float),
                     value.display_type(vm),
                 ),
@@ -178,7 +178,7 @@ impl<'a> SlFromRef<'a, Value> for u8 {
         match value {
             Value::Byte(i) => Ok(i),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Byte])),
                     value.display_type(vm),
                 ),
@@ -203,13 +203,13 @@ impl<'a> SlFromRef<'a, Value> for usize {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Int(i) => usize::try_from(I56::from_inner(&i)).map_err(|_| {
-                BridgeError::Error(ErrorStrings::fix_me_mismatched_type(
+                BridgeError::Error(ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ))
             }),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Int])),
                     value.display_type(vm),
                 ),
@@ -223,7 +223,7 @@ impl<'a> SlFromRef<'a, Value> for i64 {
         match value {
             Value::Int(i) => Ok(I56::from_inner(&i)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::Int),
                     value.display_type(vm),
                 ),

--- a/bridge_adapters/src/lisp_adapters/numbers.rs
+++ b/bridge_adapters/src/lisp_adapters/numbers.rs
@@ -1,5 +1,5 @@
 use crate::lisp_adapters::{SlFrom, SlFromRef};
-use crate::{BridgeResult, BridgeError};
+use crate::{BridgeError, BridgeResult};
 use bridge_types::{ErrorStrings, LooseFloat, LooseInt, LooseString};
 use compile_state::state::SloshVm;
 use slvm::float::F56;
@@ -16,12 +16,10 @@ impl<'a> SlFromRef<'a, Value> for () {
     fn sl_from_ref(value: Value, _vm: &'a SloshVm) -> BridgeResult<()> {
         match value {
             Value::Nil => Ok(()),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Nil),
-                    value.display_type(_vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Nil),
+                value.display_type(_vm),
+            ))),
         }
     }
 }
@@ -52,12 +50,10 @@ impl<'a> SlFromRef<'a, Value> for LooseFloat {
                     .map_err(|_e| BridgeError::Error("Not a valid float.".to_string()))?;
                 Ok(F56::from(f).0)
             }
-            _ => Err(BridgeError::Error(
-                ErrorStrings::invalid_string(
-                    <&'static str>::from(ValueType::Int),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::invalid_string(
+                <&'static str>::from(ValueType::Int),
+                value.display_type(vm),
+            ))),
         };
         res.map(LooseFloat::from)
     }
@@ -76,7 +72,8 @@ impl<'a> SlFromRef<'a, Value> for LooseInt {
             Value::Int(i) => Ok(i),
             Value::Float(f) => {
                 let f = f64::from(f);
-                let i56 = I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))?;
+                let i56 =
+                    I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))?;
                 Ok(I56::into_inner(i56))
             }
             v @ (Value::CodePoint(_)
@@ -90,15 +87,15 @@ impl<'a> SlFromRef<'a, Value> for LooseInt {
                 .or(LooseString::sl_from_ref(v, vm)?
                     .parse::<f64>()
                     .map_err(|_e| BridgeError::Error("Not a valid integer.".to_string()))
-                    .and_then(|f| I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))))
+                    .and_then(|f| {
+                        I56::into_i56_fallible(f).map_err(|e| BridgeError::Error(e.to_string()))
+                    }))
                 .map(I56::into_inner)
                 .map_err(|_e| BridgeError::Error("Not a valid integer.".to_string())),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Int),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Int),
+                value.display_type(vm),
+            ))),
         };
         res.map(LooseInt::from)
     }
@@ -137,12 +134,10 @@ impl<'a> SlFromRef<'a, Value> for i32 {
                     )
                 })
             }
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Int),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Int),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -157,12 +152,10 @@ impl<'a> SlFromRef<'a, Value> for f64 {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Float(float) => Ok(f64::from(float)),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Float),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Float),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -177,12 +170,10 @@ impl<'a> SlFromRef<'a, Value> for u8 {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Byte(i) => Ok(i),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Byte])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Byte])),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -208,12 +199,10 @@ impl<'a> SlFromRef<'a, Value> for usize {
                     value.display_type(vm),
                 ))
             }),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Int])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Int])),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -222,12 +211,10 @@ impl<'a> SlFromRef<'a, Value> for i64 {
     fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Int(i) => Ok(I56::from_inner(&i)),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    <&'static str>::from(ValueType::Int),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                <&'static str>::from(ValueType::Int),
+                value.display_type(vm),
+            ))),
         }
     }
 }

--- a/bridge_adapters/src/lisp_adapters/primitives.rs
+++ b/bridge_adapters/src/lisp_adapters/primitives.rs
@@ -52,7 +52,7 @@ impl SlFromRef<'_, Value> for KeywordAsString {
                 Ok(ret)
             }
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Keyword])),
                     value.display_type(vm),
                 ),
@@ -75,7 +75,7 @@ impl SlFromRef<'_, Value> for SymbolAsString {
                 Ok(ret)
             }
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Symbol])),
                     value.display_type(vm),
                 ),
@@ -95,7 +95,7 @@ impl SlFromRef<'_, Value> for Keyword {
         match value {
             Value::Keyword(i) => Ok(Keyword::from(i.id)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Keyword])),
                     value.display_type(vm),
                 ),
@@ -115,7 +115,7 @@ impl SlFromRef<'_, Value> for Symbol {
         match value {
             Value::Symbol(i) => Ok(Symbol::from(i.id)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([ValueType::Symbol])),
                     value.display_type(vm),
                 ),

--- a/bridge_adapters/src/lisp_adapters/primitives.rs
+++ b/bridge_adapters/src/lisp_adapters/primitives.rs
@@ -3,7 +3,7 @@
 //! and Value::False, Value::Nil, and Value::Undefined map to bool false.
 
 use crate::lisp_adapters::{SlFrom, SlFromRef};
-use crate::{BridgeResult, BridgeError};
+use crate::{BridgeError, BridgeResult};
 use bridge_types::{ErrorStrings, Keyword, KeywordAsString, Symbol, SymbolAsString};
 use compile_state::state::SloshVm;
 use slvm::{Value, ValueType, ValueTypes};
@@ -51,12 +51,10 @@ impl SlFromRef<'_, Value> for KeywordAsString {
                 let ret = KeywordAsString::from(vm.get_interned(i).to_string());
                 Ok(ret)
             }
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Keyword])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Keyword])),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -74,12 +72,10 @@ impl SlFromRef<'_, Value> for SymbolAsString {
                 let ret = SymbolAsString::from(vm.get_interned(i).to_string());
                 Ok(ret)
             }
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Symbol])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Symbol])),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -94,12 +90,10 @@ impl SlFromRef<'_, Value> for Keyword {
     fn sl_from_ref(value: Value, vm: &'_ SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Keyword(i) => Ok(Keyword::from(i.id)),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Keyword])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Keyword])),
+                value.display_type(vm),
+            ))),
         }
     }
 }
@@ -114,12 +108,10 @@ impl SlFromRef<'_, Value> for Symbol {
     fn sl_from_ref(value: Value, vm: &'_ SloshVm) -> BridgeResult<Self> {
         match value {
             Value::Symbol(i) => Ok(Symbol::from(i.id)),
-            _ => Err(BridgeError::Error(
-                ErrorStrings::mismatched_type(
-                    String::from(ValueTypes::from([ValueType::Symbol])),
-                    value.display_type(vm),
-                ),
-            )),
+            _ => Err(BridgeError::Error(ErrorStrings::mismatched_type(
+                String::from(ValueTypes::from([ValueType::Symbol])),
+                value.display_type(vm),
+            ))),
         }
     }
 }

--- a/bridge_adapters/src/lisp_adapters/text.rs
+++ b/bridge_adapters/src/lisp_adapters/text.rs
@@ -292,33 +292,34 @@ mod tests {
 
         let param = arg_types[0usize];
         match param.handle {
-            bridge_types::TypeHandle::Direct => {
-                match args.get(0usize) {
-                    None => Err(BridgeError::Error(format!(
-                        "{} not given enough arguments, expected at least {} arguments, got {}.",
-                        fn_name,
-                        1usize,
-                        args.len()
-                    ))),
-                    Some(mut arg_0) => match args.get(PARAMS_LEN) {
-                        Some(_)
-                            if PARAMS_LEN == 0
-                                || arg_types[PARAMS_LEN - 1].handle
-                                    != bridge_types::TypeHandle::VarArgs =>
-                        {
-                            let res =
-                            format!("{} given too many arguments, expected at least {} arguments, got {}.",
-                                    fn_name, 1usize, args.len());
-                            Err(BridgeError::Error(res))
-                        }
-                        _ => {
-                            let arg: &mut String = arg_0.sl_as_mut(vm)?;
-                            arg.push_str("0");
-                            Ok(())
-                        }
-                    },
-                }
-            }
+            bridge_types::TypeHandle::Direct => match args.get(0usize) {
+                None => Err(BridgeError::Error(format!(
+                    "{} not given enough arguments, expected at least {} arguments, got {}.",
+                    fn_name,
+                    1usize,
+                    args.len()
+                ))),
+                Some(mut arg_0) => match args.get(PARAMS_LEN) {
+                    Some(_)
+                        if PARAMS_LEN == 0
+                            || arg_types[PARAMS_LEN - 1].handle
+                                != bridge_types::TypeHandle::VarArgs =>
+                    {
+                        let res = format!(
+                            "{} given too many arguments, expected at least {} arguments, got {}.",
+                            fn_name,
+                            1usize,
+                            args.len()
+                        );
+                        Err(BridgeError::Error(res))
+                    }
+                    _ => {
+                        let arg: &mut String = arg_0.sl_as_mut(vm)?;
+                        arg.push_str("0");
+                        Ok(())
+                    }
+                },
+            },
             _ => Err(BridgeError::Error(format!(
                 "{} failed to parse its arguments, internal error.",
                 fn_name

--- a/bridge_adapters/src/lisp_adapters/text.rs
+++ b/bridge_adapters/src/lisp_adapters/text.rs
@@ -35,7 +35,7 @@ impl<'a> SlFromRef<'a, Value> for LooseString<'a> {
             Value::Keyword(i) => Ok(LooseString::Borrowed(vm.get_interned(i))),
             Value::StringConst(i) => Ok(LooseString::Borrowed(vm.get_interned(i))),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::String,
                         ValueType::StringConst,
@@ -57,7 +57,7 @@ impl<'a> SlFromRef<'a, Value> for char {
         match value {
             Value::CodePoint(char) => Ok(char),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type_with_context(
+                ErrorStrings::mismatched_type_with_context(
                     String::from(ValueTypes::from([ValueType::CodePoint])),
                     value.display_type(vm),
                     "Provided value can not be more than one byte, e.g. a char.",
@@ -86,7 +86,7 @@ impl<'a> SlAsRef<'a, str> for &Value {
             Value::String(h) => Ok(vm.get_string(*h)),
             Value::StringConst(i) => Ok(vm.get_interned(*i)),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::String,
                         ValueType::StringConst,
@@ -108,7 +108,7 @@ impl<'a> SlFromRef<'a, Value> for SloshChar<'a> {
             )))),
             Value::CharClusterLong(h) => Ok(SloshChar::String(Cow::Borrowed(vm.get_string(h)))),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::CharCluster,
                         ValueType::CharClusterLong,
@@ -133,7 +133,7 @@ impl<'a> SlAsMut<'a, String> for &Value {
         match self {
             Value::String(h) => vm.get_string_mut(*h).map_err(|e| BridgeError::Error(e.to_string())),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::String),
                     self.display_type(vm),
                 ),
@@ -172,7 +172,7 @@ impl<'a> SlFromRef<'a, Value> for String {
             Value::String(h) => Ok(vm.get_string(h).to_string()),
             Value::StringConst(i) => Ok(vm.get_interned(i).to_string()),
             _ => Err(BridgeError::Error(
-                ErrorStrings::fix_me_mismatched_type(
+                ErrorStrings::mismatched_type(
                     <&'static str>::from(ValueType::String),
                     value.display_type(vm),
                 ),
@@ -264,7 +264,7 @@ mod tests {
         let value = create_string(&mut vm);
         let c: BridgeResult<char> = value.sl_into_ref(&vm);
         assert!(c.is_err());
-        let expected_err = BridgeError::Error(ErrorStrings::fix_me_mismatched_type_with_context(
+        let expected_err = BridgeError::Error(ErrorStrings::mismatched_type_with_context(
             String::from(ValueTypes::from([ValueType::CodePoint])),
             value.display_type(&mut vm),
             "Provided value can not be more than one byte, e.g. a char.",

--- a/bridge_adapters/src/lisp_adapters/text.rs
+++ b/bridge_adapters/src/lisp_adapters/text.rs
@@ -1,24 +1,25 @@
 use crate::lisp_adapters::{SlAsMut, SlAsRef, SlFrom, SlFromRef, SlFromRefMut};
+use crate::{BridgeResult, BridgeError};
 use bridge_types::{ErrorStrings, LooseString, SloshChar};
 use compile_state::state::SloshVm;
 use slvm::value::ValueType;
-use slvm::{VMError, VMResult, Value, ValueTypes};
+use slvm::{Value, ValueTypes};
 use std::borrow::Cow;
 
 impl<'a> SlFrom<Cow<'a, str>> for Value {
-    fn sl_from(value: Cow<'a, str>, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: Cow<'a, str>, vm: &mut SloshVm) -> BridgeResult<Self> {
         Value::sl_from(value.to_string(), vm)
     }
 }
 
 impl<'a> SlFrom<SloshChar<'a>> for Value {
-    fn sl_from(value: SloshChar<'a>, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: SloshChar<'a>, vm: &mut SloshVm) -> BridgeResult<Self> {
         Value::sl_from(value.to_string(), vm)
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for LooseString<'a> {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::String(h) => Ok(LooseString::Borrowed(vm.get_string(h))),
             Value::CodePoint(char) => Ok(LooseString::Owned(char.to_string())),
@@ -33,7 +34,7 @@ impl<'a> SlFromRef<'a, Value> for LooseString<'a> {
             Value::Symbol(i) => Ok(LooseString::Borrowed(vm.get_interned(i))),
             Value::Keyword(i) => Ok(LooseString::Borrowed(vm.get_interned(i))),
             Value::StringConst(i) => Ok(LooseString::Borrowed(vm.get_interned(i))),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::String,
@@ -52,10 +53,10 @@ impl<'a> SlFromRef<'a, Value> for LooseString<'a> {
 }
 
 impl<'a> SlFromRef<'a, Value> for char {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::CodePoint(char) => Ok(char),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type_with_context(
                     String::from(ValueTypes::from([ValueType::CodePoint])),
                     value.display_type(vm),
@@ -67,24 +68,24 @@ impl<'a> SlFromRef<'a, Value> for char {
 }
 
 impl SlFrom<char> for Value {
-    fn sl_from(value: char, _vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: char, _vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(Value::CodePoint(value))
     }
 }
 
 /// This delegates to [`SlAsRef`] appropriately.
 impl<'a> SlFromRef<'a, Value> for &'a str {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         (&value).sl_as_ref(vm)
     }
 }
 
 impl<'a> SlAsRef<'a, str> for &Value {
-    fn sl_as_ref(&self, vm: &'a SloshVm) -> VMResult<&'a str> {
+    fn sl_as_ref(&self, vm: &'a SloshVm) -> BridgeResult<&'a str> {
         match self {
             Value::String(h) => Ok(vm.get_string(*h)),
             Value::StringConst(i) => Ok(vm.get_interned(*i)),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::String,
@@ -98,7 +99,7 @@ impl<'a> SlAsRef<'a, str> for &Value {
 }
 
 impl<'a> SlFromRef<'a, Value> for SloshChar<'a> {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::CodePoint(ch) => Ok(SloshChar::Char(ch)),
             Value::CharCluster(l, c) => Ok(SloshChar::String(Cow::Owned(format!(
@@ -106,7 +107,7 @@ impl<'a> SlFromRef<'a, Value> for SloshChar<'a> {
                 String::from_utf8_lossy(&c[0..l as usize])
             )))),
             Value::CharClusterLong(h) => Ok(SloshChar::String(Cow::Borrowed(vm.get_string(h)))),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     String::from(ValueTypes::from([
                         ValueType::CharCluster,
@@ -122,16 +123,16 @@ impl<'a> SlFromRef<'a, Value> for SloshChar<'a> {
 
 /// This delegates to [`SlAsMut`] appropriately.
 impl<'a> SlFromRefMut<'a, Value> for &'a mut String {
-    fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> VMResult<Self> {
+    fn sl_from_ref_mut(value: Value, vm: &'a mut SloshVm) -> BridgeResult<Self> {
         (&value).sl_as_mut(vm)
     }
 }
 
 impl<'a> SlAsMut<'a, String> for &Value {
-    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> VMResult<&'a mut String> {
+    fn sl_as_mut(&mut self, vm: &'a mut SloshVm) -> BridgeResult<&'a mut String> {
         match self {
-            Value::String(h) => vm.get_string_mut(*h),
-            _ => Err(VMError::new_conversion(
+            Value::String(h) => vm.get_string_mut(*h).map_err(|e| BridgeError::Error(e.to_string())),
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::String),
                     self.display_type(vm),
@@ -142,7 +143,7 @@ impl<'a> SlAsMut<'a, String> for &Value {
 }
 
 impl SlFrom<String> for Value {
-    fn sl_from(value: String, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: String, vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(vm.alloc_string(value))
     }
 }
@@ -151,7 +152,7 @@ impl<T> SlFrom<&T> for Value
 where
     T: ToString + ?Sized,
 {
-    fn sl_from(value: &T, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: &T, vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(vm.alloc_string(value.to_string()))
     }
 }
@@ -160,17 +161,17 @@ impl<T> SlFrom<&mut T> for Value
 where
     T: ToString + ?Sized,
 {
-    fn sl_from(value: &mut T, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: &mut T, vm: &mut SloshVm) -> BridgeResult<Self> {
         Ok(vm.alloc_string(value.to_string()))
     }
 }
 
 impl<'a> SlFromRef<'a, Value> for String {
-    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> VMResult<Self> {
+    fn sl_from_ref(value: Value, vm: &'a SloshVm) -> BridgeResult<Self> {
         match value {
             Value::String(h) => Ok(vm.get_string(h).to_string()),
             Value::StringConst(i) => Ok(vm.get_interned(i).to_string()),
-            _ => Err(VMError::new_conversion(
+            _ => Err(BridgeError::Error(
                 ErrorStrings::fix_me_mismatched_type(
                     <&'static str>::from(ValueType::String),
                     value.display_type(vm),
@@ -261,14 +262,14 @@ mod tests {
     fn try_conversion_error() {
         let mut vm = new_slosh_vm();
         let value = create_string(&mut vm);
-        let c: VMResult<char> = value.sl_into_ref(&vm);
+        let c: BridgeResult<char> = value.sl_into_ref(&vm);
         assert!(c.is_err());
-        let err = VMError::new_conversion(ErrorStrings::fix_me_mismatched_type_with_context(
+        let expected_err = BridgeError::Error(ErrorStrings::fix_me_mismatched_type_with_context(
             String::from(ValueTypes::from([ValueType::CodePoint])),
             value.display_type(&mut vm),
             "Provided value can not be more than one byte, e.g. a char.",
         ));
-        assert_eq!(c.err().unwrap().to_string(), err.to_string());
+        assert_eq!(c.err().unwrap().to_string(), expected_err.to_string());
     }
 
     #[test]
@@ -289,7 +290,7 @@ mod tests {
         }
     }
 
-    fn str_test_mut(vm: &mut SloshVm, args: &[Value]) -> VMResult<()> {
+    fn str_test_mut(vm: &mut SloshVm, args: &[Value]) -> BridgeResult<()> {
         let fn_name = "str_trim";
         const PARAMS_LEN: usize = 1usize;
         let arg_types: [bridge_types::Param; PARAMS_LEN] = [bridge_types::Param {
@@ -301,15 +302,9 @@ mod tests {
         match param.handle {
             bridge_types::TypeHandle::Direct => match args.get(0usize) {
                 None => {
-                    return Err(VMError::new_conversion(&*{
-                        let res = format!(
-                            "{} not given enough arguments, expected at least {} arguments, got {}.",
-                            fn_name,
-                            1usize,
-                            args.len()
-                        );
-                        res
-                    }));
+                    Err(BridgeError::Error(
+                        format!("{} not given enough arguments, expected at least {} arguments, got {}.", fn_name, 1usize, args.len())
+                    ))
                 }
                 Some(mut arg_0) => match args.get(PARAMS_LEN) {
                     Some(_)
@@ -317,15 +312,10 @@ mod tests {
                             || arg_types[PARAMS_LEN - 1].handle
                                 != bridge_types::TypeHandle::VarArgs =>
                     {
-                        return Err(VMError::new_conversion(&*{
-                            let res = format!(
-                                "{} given too many arguments, expected at least {} arguments, got {}.",
-                                fn_name,
-                                1usize,
-                                args.len()
-                            );
-                            res
-                        }));
+                        let res =
+                            format!("{} given too many arguments, expected at least {} arguments, got {}.",
+                                    fn_name, 1usize, args.len());
+                        Err(BridgeError::Error(res))
                     }
                     _ => {
                         let arg: &mut String = arg_0.sl_as_mut(vm)?;
@@ -335,15 +325,12 @@ mod tests {
                 },
             },
             _ => {
-                return Err(VMError::new_conversion(&*{
-                    let res = format!("{} failed to parse its arguments, internal error.", fn_name);
-                    res
-                }));
+                Err(BridgeError::Error(format!("{} failed to parse its arguments, internal error.", fn_name)))
             }
         }
     }
 
-    fn str_trim_test(vm: &mut SloshVm, test_str: String) -> VMResult<Value> {
+    fn str_trim_test(vm: &mut SloshVm, test_str: String) -> BridgeResult<Value> {
         let test_str = vm.alloc_string(test_str);
         let args = [test_str];
         let fn_name = "str_trim";
@@ -357,15 +344,9 @@ mod tests {
         match param.handle {
             bridge_types::TypeHandle::Direct => match args.get(0usize) {
                 None => {
-                    return Err(VMError::new_conversion(&*{
-                        let res = format!(
-                            "{} not given enough arguments, expected at least {} arguments, got {}.",
-                            fn_name,
-                            1usize,
-                            args.len()
-                        );
-                        res
-                    }));
+                    return Err(BridgeError::Error(
+                        format!("{} not given enough arguments, expected at least {} arguments, got {}.", fn_name, 1usize, args.len())
+                    ));
                 }
                 Some(arg_0) => match args.get(PARAMS_LEN) {
                     Some(_)
@@ -373,18 +354,13 @@ mod tests {
                             || arg_types[PARAMS_LEN - 1].handle
                                 != bridge_types::TypeHandle::VarArgs =>
                     {
-                        return Err(VMError::new_conversion(&*{
-                            let res = format!(
-                                "{} given too many arguments, expected at least {} arguments, got {}.",
-                                fn_name,
-                                1usize,
-                                args.len()
-                            );
-                            res
-                        }));
+                        Err(BridgeError::Error(
+                                            format!("{} given too many arguments, expected at least {} arguments, got {}.",
+                                                    fn_name, 1usize, args.len())
+                        ))
                     }
                     _ => {
-                        return {
+                        {
                             let arg: String = (*arg_0).sl_into_ref(vm)?;
                             arg.trim().to_string().sl_into(vm)
                         };
@@ -392,10 +368,9 @@ mod tests {
                 },
             },
             _ => {
-                return Err(VMError::new_conversion(&*{
-                    let res = format!("{} failed to parse its arguments, internal error.", fn_name);
-                    res
-                }));
+                Err(BridgeError::Error(
+                    format!("{} failed to parse its arguments, internal error.", fn_name)
+                ))
             }
         }
     }
@@ -415,21 +390,21 @@ mod tests {
             .expect("&Value::String can be converted to String");
         let kwd_val = create_keyword(vm);
 
-        let e: VMResult<String> = kwd_val.sl_into_ref(vm);
+        let e: BridgeResult<String> = kwd_val.sl_into_ref(vm);
         e.expect_err("Can not convert keyword to String");
 
         let _s: &str = (&val)
             .sl_as_ref(vm)
             .expect("&Value::String can be converted to &str");
 
-        let e: VMResult<&str> = (&kwd_val).sl_as_ref(vm);
+        let e: BridgeResult<&str> = (&kwd_val).sl_as_ref(vm);
         e.expect_err("Can not convert keyword to &str");
 
         let _s: &mut String = (&val)
             .sl_as_mut(vm)
             .expect("&Value::String can be converted to &mut String");
 
-        let e: VMResult<&mut String> = (&kwd_val).sl_as_mut(vm);
+        let e: BridgeResult<&mut String> = (&kwd_val).sl_as_mut(vm);
         e.expect_err("Can not convert keyword to &mut String");
     }
 

--- a/bridge_types/src/lib.rs
+++ b/bridge_types/src/lib.rs
@@ -286,12 +286,12 @@ pub struct Param {
 pub struct ErrorStrings {}
 
 impl ErrorStrings {
-    pub fn mismatched_type(
+    pub fn mismatched_type_context(
         expected: impl AsRef<str>,
         got: impl AsRef<str>,
-        additional: impl AsRef<str>,
+        context: impl AsRef<str>,
     ) -> String {
-        if additional.as_ref().is_empty() {
+        if context.as_ref().is_empty() {
             format!(
                 "mismatched type input, expected value of type {}, got {}.",
                 expected.as_ref(),
@@ -302,17 +302,17 @@ impl ErrorStrings {
                 "mismatched type input, expected value of type {}, got {}. {}",
                 expected.as_ref(),
                 got.as_ref(),
-                additional.as_ref(),
+                context.as_ref(),
             )
         }
     }
 
-    pub fn invalid_string(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
-        Self::mismatched_type(expected, got, "")
+    pub fn mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
+        Self::mismatched_type_context(expected, got, "")
     }
 
-    pub fn mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
-        Self::mismatched_type(expected, got, "")
+    pub fn invalid_string(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
+        Self::mismatched_type_context(expected, got, "")
     }
 
     pub fn mismatched_type_with_context(
@@ -320,6 +320,6 @@ impl ErrorStrings {
         got: impl AsRef<str>,
         additional: impl AsRef<str>,
     ) -> String {
-        Self::mismatched_type(expected, got, additional)
+        Self::mismatched_type_context(expected, got, additional)
     }
 }

--- a/bridge_types/src/lib.rs
+++ b/bridge_types/src/lib.rs
@@ -287,22 +287,19 @@ pub struct ErrorStrings {}
 
 impl ErrorStrings {
     pub fn mismatched_type(
-        fn_name: impl AsRef<str>,
         expected: impl AsRef<str>,
         got: impl AsRef<str>,
         additional: impl AsRef<str>,
     ) -> String {
         if additional.as_ref().is_empty() {
             format!(
-                "{}: mismatched type input, expected value of type {}, got {}.",
-                fn_name.as_ref(),
+                "mismatched type input, expected value of type {}, got {}.",
                 expected.as_ref(),
                 got.as_ref(),
             )
         } else {
             format!(
-                "{}: mismatched type input, expected value of type {}, got {}. {}",
-                fn_name.as_ref(),
+                "mismatched type input, expected value of type {}, got {}. {}",
                 expected.as_ref(),
                 got.as_ref(),
                 additional.as_ref(),
@@ -311,11 +308,11 @@ impl ErrorStrings {
     }
 
     pub fn fix_me_invalid_string(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
-        Self::mismatched_type("fixme_invalid_string", expected, got, "")
+        Self::mismatched_type(expected, got, "")
     }
 
     pub fn fix_me_mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
-        Self::mismatched_type("fixme", expected, got, "")
+        Self::mismatched_type(expected, got, "")
     }
 
     pub fn fix_me_mismatched_type_with_context(
@@ -323,6 +320,6 @@ impl ErrorStrings {
         got: impl AsRef<str>,
         additional: impl AsRef<str>,
     ) -> String {
-        Self::mismatched_type("fixme", expected, got, additional)
+        Self::mismatched_type(expected, got, additional)
     }
 }

--- a/bridge_types/src/lib.rs
+++ b/bridge_types/src/lib.rs
@@ -307,15 +307,15 @@ impl ErrorStrings {
         }
     }
 
-    pub fn fix_me_invalid_string(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
+    pub fn invalid_string(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
         Self::mismatched_type(expected, got, "")
     }
 
-    pub fn fix_me_mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
+    pub fn mismatched_type(expected: impl AsRef<str>, got: impl AsRef<str>) -> String {
         Self::mismatched_type(expected, got, "")
     }
 
-    pub fn fix_me_mismatched_type_with_context(
+    pub fn mismatched_type_with_context(
         expected: impl AsRef<str>,
         got: impl AsRef<str>,
         additional: impl AsRef<str>,

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -36,7 +36,8 @@ fn get_builtin_slot_and_value(vm: &mut SloshVm, s: impl AsRef<str>) -> (u32, Val
 pub fn noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "noop-fn")?.to_string();
+        let fcn =
+            BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "noop-fn")?.to_string();
         noop_swap_internal(environment, fcn, NoopSwap::MakeNoop)
     } else {
         Err(VMError::new_vm(
@@ -48,7 +49,8 @@ pub fn noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value
 pub fn un_noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "un-noop-fn")?.to_string();
+        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "un-noop-fn")?
+            .to_string();
         noop_swap_internal(environment, fcn, NoopSwap::MakeNotNoop)
     } else {
         Err(VMError::new_vm(
@@ -94,7 +96,8 @@ pub fn noop_swap_internal(
 fn is_noop(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "is-noop")?.to_string();
+        let fcn =
+            BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "is-noop")?.to_string();
         let (_sym_slot, inplace_val) = get_builtin_slot_and_value(environment, fcn);
         let (_noop_slot, noop_val) = get_builtin_slot_and_value(environment, NOOP);
 

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -2,6 +2,7 @@ extern crate core;
 
 use bridge_adapters::add_builtin;
 use bridge_adapters::lisp_adapters::SlFromRef;
+use bridge_adapters::BridgeError;
 use bridge_macros::sl_sh_fn;
 use bridge_types::{KeywordAsString, LooseString};
 use compile_state::state::{SloshVm, SloshVmTrait};
@@ -35,7 +36,7 @@ fn get_builtin_slot_and_value(vm: &mut SloshVm, s: impl AsRef<str>) -> (u32, Val
 pub fn noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = LooseString::sl_from_ref(v, environment)?.to_string();
+        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "noop-fn")?.to_string();
         noop_swap_internal(environment, fcn, NoopSwap::MakeNoop)
     } else {
         Err(VMError::new_vm(
@@ -47,7 +48,7 @@ pub fn noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value
 pub fn un_noop_fn(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = LooseString::sl_from_ref(v, environment)?.to_string();
+        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "un-noop-fn")?.to_string();
         noop_swap_internal(environment, fcn, NoopSwap::MakeNotNoop)
     } else {
         Err(VMError::new_vm(
@@ -93,7 +94,7 @@ pub fn noop_swap_internal(
 fn is_noop(environment: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
     if registers.len() == 1 {
         let v = registers[0];
-        let fcn = LooseString::sl_from_ref(v, environment)?.to_string();
+        let fcn = BridgeError::with_fn(LooseString::sl_from_ref(v, environment), "is-noop")?.to_string();
         let (_sym_slot, inplace_val) = get_builtin_slot_and_value(environment, fcn);
         let (_noop_slot, noop_val) = get_builtin_slot_and_value(environment, NOOP);
 

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate core;
 
+use bridge_adapters::BridgeError;
 use bridge_adapters::add_builtin;
 use bridge_adapters::lisp_adapters::SlFromRef;
-use bridge_adapters::BridgeError;
 use bridge_macros::sl_sh_fn;
 use bridge_types::{KeywordAsString, LooseString};
 use compile_state::state::{SloshVm, SloshVmTrait};

--- a/builtins/trybuild/tests/enforce_return_fail.stderr
+++ b/builtins/trybuild/tests/enforce_return_fail.stderr
@@ -1,4 +1,4 @@
-error: Functions can only return GenericArguments of type ["VMResult", "Option"], try wrapping this value in Option or VMResult.
+error: Functions can only return GenericArguments of type ["VMResult", "Option", "slvm::VMResult"], try wrapping this value in Option or VMResult.
  --> trybuild/tests/enforce_return_fail.rs:7:28
   |
 7 | pub fn invalid_return() -> Result<(), ()> {

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -1,8 +1,7 @@
 use crate::docs::legacy as legacy_docs;
 use bridge_adapters::add_builtin;
 use bridge_adapters::lisp_adapters::SlFrom;
-use bridge_adapters::{BridgeResult, BridgeError};
-use bridge_macros::sl_sh_fn;
+use bridge_adapters::{BridgeError, BridgeResult};
 use compile_state::state::{SloshVm, SloshVmTrait};
 use lazy_static::lazy_static;
 use mdbook::book::{Book, Chapter};
@@ -1459,7 +1458,7 @@ fn doc_search(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
         // Generate vector of doc maps
         let mut result_values = Vec::new();
         for doc in results {
-            match Value::sl_from(doc, vm) {
+            match BridgeError::with_fn(Value::sl_from(doc, vm), "doc-search") {
                 Ok(val) => result_values.push(val),
                 Err(e) => {
                     vm.unpause_gc();

--- a/slosh_test_lib/src/docs.rs
+++ b/slosh_test_lib/src/docs.rs
@@ -1,6 +1,7 @@
 use crate::docs::legacy as legacy_docs;
 use bridge_adapters::add_builtin;
 use bridge_adapters::lisp_adapters::SlFrom;
+use bridge_adapters::{BridgeResult, BridgeError};
 use bridge_macros::sl_sh_fn;
 use compile_state::state::{SloshVm, SloshVmTrait};
 use lazy_static::lazy_static;
@@ -492,7 +493,7 @@ fn insert_nil_section(map: &mut VMHashMap, key: &'static str, vm: &mut SloshVm) 
 }
 
 impl SlFrom<SloshDoc> for VMHashMap {
-    fn sl_from(value: SloshDoc, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: SloshDoc, vm: &mut SloshVm) -> BridgeResult<Self> {
         let mut map = Self::with_capacity(4);
         match (value.doc_string.usage, value.doc_string.example) {
             (Some(usage), Some(example)) => {
@@ -519,7 +520,7 @@ impl SlFrom<SloshDoc> for VMHashMap {
 }
 
 impl SlFrom<SloshDoc> for Value {
-    fn sl_from(value: SloshDoc, vm: &mut SloshVm) -> VMResult<Self> {
+    fn sl_from(value: SloshDoc, vm: &mut SloshVm) -> BridgeResult<Self> {
         let map = VMHashMap::sl_from(value, vm)?;
         Ok(vm.alloc_map(map))
     }
@@ -534,7 +535,7 @@ fn doc_map(vm: &mut SloshVm, registers: &[Value]) -> VMResult<Value> {
             vm.pause_gc();
 
             let res = match SloshDoc::new(*g, vm, Namespace::Global) {
-                Ok(slosh_doc) => Value::sl_from(slosh_doc, vm),
+                Ok(slosh_doc) => BridgeError::with_fn(Value::sl_from(slosh_doc, vm), "doc-map"),
                 Err(e) => Err(VMError::from(e)),
             };
             // Unpause GC, this MUST happen so no early returns (looking at you ?).


### PR DESCRIPTION
Create another error type  to hold error string, convert it to VmError and add fn_name so it's less confusing which errors are failing. BridgeResult get's wrapped by VmError inside the macro call, and adds the context of the calling function's name. This allows the error to report 
`"ERROR: [conversion]: ->int: mismatched type input, expected value of type Int, got Vector."`
 instead of 
`"ERROR: [conversion]: mismatched type input, expected value of type Int, got Vector."`

this has been something i've been meaning to do for awhile.

There's still a lot to do though. I'm wondering if we can't do something similar to what Rust does with miette?